### PR TITLE
Fix TIFF file reading and saving in file browser

### DIFF
--- a/PicView/FileHandling/OpenSave.cs
+++ b/PicView/FileHandling/OpenSave.cs
@@ -27,9 +27,10 @@ namespace PicView.FileHandling
         /// </summary>
         internal const string FilterFiles =
             "*|*.bmp;*.jpg;*.png;*.tif;*.tiff;*.gif;*.ico;*.jpeg;*.webp;*.qoi;*.psd;*.psb;*.xcf;*.avif;*.jp2;*.hdr;*.heif;*.heif;*.wdp;"
-            + "|jpg|*.jpg;*.jpeg"                                                                          // JPG
+            + "|jpg|*.jpg;*.jpeg;"                                                                          // JPG
             + "|PNG|*.png;"                                                                                 // PNG
             + "|gif|*.gif;"                                                                                 // GIF
+            + "|TIFF|*.tif;*.tiff;"                                                                         // TIF
             + "|ico|*.ico;"                                                                                 // ICO
             + "|svg|*.svg;"                                                                                 // SVG
             + "|webp|*.webp;"                                                                               // WEBP
@@ -39,13 +40,13 @@ namespace PicView.FileHandling
             + "|HEIC|*.heic;*.heif;"                                                                        // HEIC
             + "|HDR|*.hdr;"                                                                                 // HDR
             + "|svg|*.svg;"                                                                                 // SVG
-            + "|Photoshop|*.psd;*.psb"                                                                      // PSD
-            + "|GIMP|*.xcf"                                                                                 // GIMP
-            + "|QOI|*.qoi"                                                                                  // GQOI (Quite OK Image
-            + "|Base64|*.b64"                                                                               // Base64
-            + "|Archives|*.zip;*.7zip;*.7z;*.rar;*.bzip2;*.tar;*.wim;*.iso;*.cab"                           // Archives
-            + "|Comics|*.cbr;*.cb7;*.cbt;*.cbz;*.xz"                                                        // Comics
-            + "|Camera files|*.orf;*.cr2;*.crw;*.dng;*.raf;*.ppm;*.raw;*.mrw;*.nef;*.pef;*.3xf;*.arw";      // Camera files
+            + "|Photoshop|*.psd;*.psb;"                                                                     // PSD
+            + "|GIMP|*.xcf;"                                                                                // GIMP
+            + "|QOI|*.qoi;"                                                                                 // GQOI (Quite OK Image
+            + "|Base64|*.b64;"                                                                              // Base64
+            + "|Archives|*.zip;*.7zip;*.7z;*.rar;*.bzip2;*.tar;*.wim;*.iso;*.cab;"                          // Archives
+            + "|Comics|*.cbr;*.cb7;*.cbt;*.cbz;*.xz;"                                                       // Comics
+            + "|Camera files|*.orf;*.cr2;*.crw;*.dng;*.raf;*.ppm;*.raw;*.mrw;*.nef;*.pef;*.3xf;*.arw;";     // Camera files
 
         /// <summary>
         /// Opens image in File Explorer

--- a/PicView/FileHandling/OpenSave.cs
+++ b/PicView/FileHandling/OpenSave.cs
@@ -26,7 +26,7 @@ namespace PicView.FileHandling
         ///  TODO update for and check file support
         /// </summary>
         internal const string FilterFiles =
-            "*|*.bmp;*.jpg;*.png;.tif;*.gif;*.ico;*.jpeg;*.webp;*.qoi;*.psd;*.psb;*.xcf;*.avif;*.jp2;*.hdr;*.heif;*.heif;*.wdp;"
+            "*|*.bmp;*.jpg;*.png;*.tif;*.tiff;*.gif;*.ico;*.jpeg;*.webp;*.qoi;*.psd;*.psb;*.xcf;*.avif;*.jp2;*.hdr;*.heif;*.heif;*.wdp;"
             + "|jpg| *.jpg;*.jpeg"                                                                          // JPG
             + "|PNG|*.png;"                                                                                 // PNG
             + "|gif|*.gif;"                                                                                 // GIF

--- a/PicView/FileHandling/OpenSave.cs
+++ b/PicView/FileHandling/OpenSave.cs
@@ -27,7 +27,7 @@ namespace PicView.FileHandling
         /// </summary>
         internal const string FilterFiles =
             "*|*.bmp;*.jpg;*.png;*.tif;*.tiff;*.gif;*.ico;*.jpeg;*.webp;*.qoi;*.psd;*.psb;*.xcf;*.avif;*.jp2;*.hdr;*.heif;*.heif;*.wdp;"
-            + "|jpg| *.jpg;*.jpeg"                                                                          // JPG
+            + "|jpg|*.jpg;*.jpeg"                                                                          // JPG
             + "|PNG|*.png;"                                                                                 // PNG
             + "|gif|*.gif;"                                                                                 // GIF
             + "|ico|*.ico;"                                                                                 // ICO


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, TIFF files cannot be opened because the file dialogue filter is misconfigured. This PR fixes the filter option for TIFF files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
