### PR TITLE
New keybinding view model and filtering

### DIFF
--- a/src/PicView.Avalonia.MacOS/Views/KeybindingsWindow.axaml
+++ b/src/PicView.Avalonia.MacOS/Views/KeybindingsWindow.axaml
@@ -8,7 +8,6 @@
     x:Class="PicView.Avalonia.MacOS.Views.KeybindingsWindow"
     x:DataType="viewModels:MainViewModel"
     xmlns="https://github.com/avaloniaui"
-    xmlns:customControls="clr-namespace:PicView.Avalonia.CustomControls;assembly=PicView.Avalonia"
     xmlns:main="clr-namespace:PicView.Avalonia.Views.Main;assembly=PicView.Avalonia"
     xmlns:viewModels="clr-namespace:PicView.Avalonia.ViewModels;assembly=PicView.Avalonia"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
@@ -41,9 +40,7 @@
                 Background="{DynamicResource WindowBackgroundColor}"
                 Focusable="True"
                 Margin="0,28,0,0">
-                <customControls:AutoScrollViewer Padding="5,2,5,10">
-                    <main:KeybindingsView x:Name="XKeybindingsView" />
-                </customControls:AutoScrollViewer>
+                <main:KeybindingsView Padding="0,2,0,10" x:Name="XKeybindingsView" />
             </Border>
         </Panel>
     </Border>

--- a/src/PicView.Avalonia.MacOS/WindowImpl/WindowInitializer.cs
+++ b/src/PicView.Avalonia.MacOS/WindowImpl/WindowInitializer.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using PicView.Avalonia.FileSystem;
 using PicView.Avalonia.Functions;
+using PicView.Avalonia.Input;
 using PicView.Avalonia.Interfaces;
 using PicView.Avalonia.MacOS.PlatformUpdate;
 using PicView.Avalonia.MacOS.Printing;
@@ -141,6 +142,26 @@ public class WindowInitializer : IPlatformSpecificUpdate
                 await vm.Window.KeybindingWindowConfig.LoadAsync();
             }
 
+            if (vm.Keybindings is null)
+            {
+                vm.Keybindings = new KeybindingsViewModel();
+                vm.Keybindings.ResetKeybindingsCommand = new ReactiveCommand(async (_, _) =>
+                {
+                    _keybindingsWindow.Close();
+                    await Task.Run(() =>
+                    {
+                        KeybindingManager.SetDefaultKeybindings(vm.PlatformService);
+                        FunctionsKeyHelper.ResetKeybindings(vm.Keybindings);
+                    }, CancellationToken.None);
+                    await ShowKeybindingsWindow(vm);
+                });
+            }
+            
+            _ = Task.Run(() =>
+            {
+                FunctionsKeyHelper.LoadKeybindingsViewModel(vm.Keybindings);
+            });
+            
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
                 _keybindingsWindow = new KeybindingsWindow(vm.Window.KeybindingWindowConfig)

--- a/src/PicView.Avalonia.Win32/Views/KeybindingsWindow.axaml
+++ b/src/PicView.Avalonia.Win32/Views/KeybindingsWindow.axaml
@@ -80,16 +80,12 @@
                     x:Name="TitleText" />
             </DockPanel>
 
-            <customControls:AutoScrollViewer
-                Background="Transparent"
+            <Border
+                Background="{DynamicResource WindowBackgroundColor}"
                 Focusable="True"
-                Margin="0,28,0,0"
-                Theme="{StaticResource Main}">
-                <main:KeybindingsView
-                    Background="{DynamicResource NoisyTexture}"
-                    Padding="5,2,5,10"
-                    x:Name="KeybindingsView" />
-            </customControls:AutoScrollViewer>
+                Margin="0,28,0,0">
+                <main:KeybindingsView Padding="0,2,0,10" x:Name="KeybindingsView" />
+            </Border>
         </Panel>
     </Border>
 </Window>

--- a/src/PicView.Avalonia.Win32/WindowImpl/WindowInitializer.cs
+++ b/src/PicView.Avalonia.Win32/WindowImpl/WindowInitializer.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using PicView.Avalonia.FileSystem;
 using PicView.Avalonia.Functions;
+using PicView.Avalonia.Input;
 using PicView.Avalonia.Interfaces;
 using PicView.Avalonia.Navigation;
 using PicView.Avalonia.Update;
@@ -156,6 +157,26 @@ public class WindowInitializer : IPlatformSpecificUpdate
                 vm.Window.KeybindingWindowConfig = new KeybindingWindowConfig();
                 await vm.Window.KeybindingWindowConfig.LoadAsync();
             }
+            
+            if (vm.Keybindings is null)
+            {
+                vm.Keybindings = new KeybindingsViewModel();
+                vm.Keybindings.ResetKeybindingsCommand = new ReactiveCommand(async (_, _) =>
+                {
+                    _keybindingsWindow.Close();
+                    await Task.Run(() =>
+                    {
+                        KeybindingManager.SetDefaultKeybindings(vm.PlatformService);
+                        FunctionsKeyHelper.ResetKeybindings(vm.Keybindings);
+                    }, CancellationToken.None);
+                    await ShowKeybindingsWindow(vm);
+                });
+            }
+            
+            _ = Task.Run(() =>
+            {
+                FunctionsKeyHelper.LoadKeybindingsViewModel(vm.Keybindings);
+            });
 
             await Dispatcher.UIThread.InvokeAsync(() =>
             {

--- a/src/PicView.Avalonia/CustomControls/FuncTextBox.cs
+++ b/src/PicView.Avalonia/CustomControls/FuncTextBox.cs
@@ -57,6 +57,22 @@ public class FuncTextBox : TextBox
     }
 
     protected override Type StyleKeyOverride => typeof(TextBox);
+    
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        if (change.Property == IsReadOnlyProperty)
+        {
+            if (IsReadOnly)
+            {
+                PseudoClasses.Add(":readonly");
+            }
+            else
+            {
+                PseudoClasses.Remove(":readonly");
+            }
+        }
+        base.OnPropertyChanged(change);
+    }
 
     private void LoadContextMenu()
     {

--- a/src/PicView.Avalonia/CustomControls/KeybindTextBox.cs
+++ b/src/PicView.Avalonia/CustomControls/KeybindTextBox.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Threading;
@@ -32,11 +33,15 @@ public class KeybindTextBox : TextBox
 
     public KeybindTextBox()
     {
-        SubscribeToMethodNameChanges();
         SetupKeyEventHandlers();
-
+        Loaded += OnLoaded;
         GotFocus += OnGotFocus;
         LostFocus += OnLostFocus;
+    }
+
+    private void OnLoaded(object? sender, RoutedEventArgs e)
+    {
+        SubscribeToMethodNameChanges();
     }
 
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
@@ -68,9 +73,29 @@ public class KeybindTextBox : TextBox
 
     private void SubscribeToMethodNameChanges()
     {
+        if (string.IsNullOrEmpty(MethodName))
+        {
+            return;
+        }
         this.GetObservable(MethodNameProperty).ToObservable()
-            .Subscribe(_ => Text = GetFunctionKey())
+            .Subscribe(_ => Text = FunctionsKeyHelper.GetFunctionKeyName(MethodName, IsReadOnly, Alt))
             .AddTo(_disposables);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        if (change.Property == IsReadOnlyProperty)
+        {
+            if (IsReadOnly)
+            {
+                PseudoClasses.Add(":readonly");
+            }
+            else
+            {
+                PseudoClasses.Remove(":readonly");
+            }
+        }
+        base.OnPropertyChanged(change);
     }
 
     private void SetupKeyEventHandlers()
@@ -129,14 +154,14 @@ public class KeybindTextBox : TextBox
     private void OnLostFocus(object? sender, RoutedEventArgs e)
     {
         ApplyDefaultForegroundColor();
-        Text = GetFunctionKey();
+        Text = FunctionsKeyHelper.GetFunctionKeyName(MethodName, IsReadOnly, Alt);
         MainKeyboardShortcuts.IsEscKeyEnabled = true;
     }
 
     private void KeyUpHandler()
     {
         ApplyDefaultForegroundColor();
-        Text = GetFunctionKey();
+        Text = FunctionsKeyHelper.GetFunctionKeyName(MethodName, IsReadOnly, Alt);
     }
 
     private void ApplyReadOnlyBorderColor()
@@ -254,50 +279,12 @@ public class KeybindTextBox : TextBox
         }
     }
 
-    private string GetFunctionKey()
+    protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
     {
-        if (string.IsNullOrEmpty(MethodName))
-        {
-            return string.Empty;
-        }
-
-        if (IsReadOnly)
-        {
-            switch (MethodName)
-            {
-                case "ScrollUpInternal":
-                    var rotateRightKey = KeybindingManager.CustomShortcuts.Where(x => x.Value?.Method?.Name == "Up")
-                        ?.Select(x => x.Key).ToList() ?? null;
-                    return rotateRightKey is not { Count: > 0 } ? string.Empty :
-                        Alt ? rotateRightKey.LastOrDefault().ToString() : rotateRightKey.FirstOrDefault().ToString();
-
-                case "ScrollDownInternal":
-                    var rotateLeftKey = KeybindingManager.CustomShortcuts.Where(x => x.Value?.Method?.Name == "Down")
-                        ?.Select(x => x.Key).ToList() ?? null;
-                    return rotateLeftKey is not { Count: > 0 } ? string.Empty :
-                        Alt ? rotateLeftKey.LastOrDefault().ToString() : rotateLeftKey.FirstOrDefault().ToString();
-            }
-        }
-
-        // Find the key associated with the specified function
-        var keys = KeybindingManager.CustomShortcuts.Where(x => x.Value?.Method?.Name == MethodName)?.Select(x => x.Key)
-            .ToList() ?? null;
-
-        if (keys is null)
-        {
-            return string.Empty;
-        }
-
-        return keys.Count switch
-        {
-            <= 0 => string.Empty,
-            1 => Alt ? string.Empty : FormatPlus(keys.FirstOrDefault().ToString()),
-            _ => Alt ? FormatPlus(keys.LastOrDefault().ToString()) : FormatPlus(keys.FirstOrDefault().ToString())
-        };
-
-        string FormatPlus(string value)
-        {
-            return string.IsNullOrEmpty(value) ? string.Empty : value.Replace("+", " + ");
-        }
+        base.OnDetachedFromLogicalTree(e);
+        _disposables.Dispose();
+        Loaded -= OnLoaded;
+        GotFocus -= OnGotFocus;
+        LostFocus -= OnLostFocus;
     }
 }

--- a/src/PicView.Avalonia/Functions/FunctionsKeyHelper.cs
+++ b/src/PicView.Avalonia/Functions/FunctionsKeyHelper.cs
@@ -1,0 +1,290 @@
+using System.Collections.ObjectModel;
+using Avalonia.Input;
+using PicView.Avalonia.Input;
+using PicView.Core.DebugTools;
+using PicView.Core.Localization;
+using PicView.Core.Models;
+using PicView.Core.ViewModels;
+
+namespace PicView.Avalonia.Functions;
+
+public static class FunctionsKeyHelper
+{
+    private static bool _isInitialized;
+    public static string GetFunctionKeyName(string methodName, bool isReadOnly, bool alt)
+    {
+        if (string.IsNullOrEmpty(methodName))
+        {
+            return string.Empty;
+        }
+
+        if (isReadOnly)
+        {
+            switch (methodName)
+            {
+                case "ScrollUpInternal":
+                    var rotateRightKey = KeybindingManager.CustomShortcuts.Where(x => x.Value?.Method?.Name == "Up")
+                        ?.Select(x => x.Key).ToList() ?? null;
+                    return rotateRightKey is not { Count: > 0 } ? string.Empty :
+                        alt ? rotateRightKey.LastOrDefault().ToString() : rotateRightKey.FirstOrDefault().ToString();
+
+                case "ScrollDownInternal":
+                    var rotateLeftKey = KeybindingManager.CustomShortcuts.Where(x => x.Value?.Method?.Name == "Down")
+                        ?.Select(x => x.Key).ToList() ?? null;
+                    return rotateLeftKey is not { Count: > 0 } ? string.Empty :
+                        alt ? rotateLeftKey.LastOrDefault().ToString() : rotateLeftKey.FirstOrDefault().ToString();
+            }
+        }
+
+        // Find the key associated with the specified function
+        var keys = GetKeysFromFunction(methodName);
+
+        var keyGestures = keys ?? keys.ToArray();
+        return keyGestures.Length switch
+        {
+            <= 0 => string.Empty,
+            1 => alt ? string.Empty : FormatPlus(keyGestures?.FirstOrDefault()?.ToString() ?? string.Empty),
+            _ => alt ? FormatPlus(keyGestures.LastOrDefault()?.ToString() ?? string.Empty) : FormatPlus(keyGestures.FirstOrDefault().ToString())
+        };
+    }
+    
+    private static string FormatPlus(string value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("+", " + ");
+
+    public static KeyGesture[] GetKeysFromFunction(string methodName)
+    {
+        var keys = KeybindingManager.CustomShortcuts.Where(x => x.Value?.Method?.Name == methodName)?
+            .Select(x => x.Key) ?? null;
+
+        return keys as KeyGesture[] ?? keys.ToArray();
+    }
+
+    public static void ResetKeybindings(KeybindingsViewModel keybindings)
+    {
+        _isInitialized = false;
+        LoadKeybindingsViewModel(keybindings);
+    }
+
+    public static void LoadKeybindingsViewModel(KeybindingsViewModel keybindings)
+    {
+        try
+        {
+            if (_isInitialized)
+            {
+                return;
+            }
+            LoadKeybindingsViewModelCore(keybindings);
+        }
+        catch (Exception e)
+        {
+            DebugHelper.LogDebug(nameof(FunctionsKeyHelper), nameof(LoadKeybindingsViewModel), e);
+        }
+        finally
+        {
+            _isInitialized = true;
+        }
+    }
+
+    private static void LoadKeybindingsViewModelCore(KeybindingsViewModel keybindings)
+    {
+        // TODO: Find a way to determine correct translations, so these can be added dynamically instead of hardcoding them
+        
+        // Navigation keys
+        var navKeys = keybindings.NavigationKeys.Value;
+        AddBinding(navKeys, "Next", TranslationManager.Translation.NextImage);
+        AddBinding(navKeys, "Next10", TranslationManager.Translation.AdvanceBy10Images);
+        AddBinding(navKeys, "Next100", TranslationManager.Translation.AdvanceBy100Images);
+        AddBinding(navKeys, "Prev", TranslationManager.Translation.PrevImage);
+        AddBinding(navKeys, "Prev10", TranslationManager.Translation.GoBackBy10Images);
+        AddBinding(navKeys, "Prev100", TranslationManager.Translation.GoBackBy100Images);
+        AddBinding(navKeys, "Last", TranslationManager.Translation.LastImage);
+        AddBinding(navKeys, "First", TranslationManager.Translation.FirstImage);
+        AddBinding(navKeys, "NextFolder", TranslationManager.Translation.NextFolder);
+        AddBinding(navKeys, "PrevFolder", TranslationManager.Translation.PrevFolder);
+        AddBinding(navKeys, "Search", TranslationManager.Translation.Search);
+        AddBinding(navKeys, "GalleryClick", TranslationManager.Translation.SelectGalleryThumb);
+        AddBinding(navKeys, "ToggleLooping", TranslationManager.Translation.ToggleLooping);
+        
+        // Scroll and rotate keys
+        var scrollKeys = keybindings.ScrollAndRotateKeys.Value;
+        AddBinding(scrollKeys, "Up", TranslationManager.Translation.RotateRight);
+
+        // Special case: ScrollUpInternal is read-only and derived from 'Up' keys
+        var upInternalCheck = KeybindingManager.CustomShortcuts.Where(x => x.Value?.Method?.Name == "Up")
+            ?.Select(x => x.Key).ToList() ?? null;
+        var scrollUpInternal = new KeyBindingsModel
+        {
+            MethodName = "ScrollUpInternal",
+            FriendlyMethodName = TranslationManager.Translation.ScrollUp,
+            Key = FormatPlus(upInternalCheck?.FirstOrDefault()?.ToString() ?? string.Empty),
+            AltKey = FormatPlus(upInternalCheck?.LastOrDefault()?.ToString() ?? string.Empty),
+            IsReadOnly = true
+        };
+        keybindings.ScrollAndRotateKeys.Value.Add(scrollUpInternal);
+        
+        AddBinding(scrollKeys, "ScrollUp", TranslationManager.Translation.RotateRight);
+        AddBinding(scrollKeys, "RotateLeft", TranslationManager.Translation.RotateRight);
+        
+        // Special case: ScrollDownInternal is read-only and derived from 'Down' keys
+        var downInternalCheck = KeybindingManager.CustomShortcuts.Where(x => x.Value?.Method?.Name == "Down")
+            ?.Select(x => x.Key).ToList() ?? null;
+        var scrollDownInternal = new KeyBindingsModel
+        {
+            MethodName = "ScrollDownInternal",
+            FriendlyMethodName = TranslationManager.Translation.ScrollDown,
+            Key = FormatPlus(downInternalCheck?.FirstOrDefault()?.ToString() ?? string.Empty),
+            AltKey = FormatPlus(downInternalCheck?.LastOrDefault()?.ToString() ?? string.Empty),
+            IsReadOnly = true
+        };
+        keybindings.ScrollAndRotateKeys.Value.Add(scrollDownInternal);
+        
+        AddBinding(scrollKeys, "ScrollDown", TranslationManager.Translation.ScrollDown);
+        AddBinding(scrollKeys, "ScrollToTop", TranslationManager.Translation.ScrollToTop);
+        AddBinding(scrollKeys, "ScrollToBottom", TranslationManager.Translation.ScrollToBottom);
+        AddBinding(scrollKeys, "ToggleScroll", TranslationManager.Translation.ToggleScroll);
+        AddBinding(scrollKeys, "ChangeCtrlZoom", TranslationManager.Translation.CtrlToZoom);
+        
+        // Zoom keys
+        var zoomKeys = keybindings.ZoomKeys.Value;
+        AddBinding(zoomKeys, "ZoomIn", TranslationManager.Translation.ZoomIn);
+        AddBinding(zoomKeys, "ZoomOut", TranslationManager.Translation.ZoomOut);
+        AddBinding(zoomKeys, "ResetZoom", TranslationManager.Translation.ResetZoom);
+        
+        // Special case: Show pan as read only
+        zoomKeys.Add(new KeyBindingsModel
+        {
+            FriendlyMethodName = TranslationManager.Translation.Pan,
+            Key = TranslationManager.Translation.MouseDrag,
+            IsReadOnly = true
+        });
+        
+        var imageControl = keybindings.ImageControlKeys.Value;
+        AddBinding(imageControl, "SideBySide", TranslationManager.Translation.SideBySide);
+        AddBinding(imageControl, "Stretch", TranslationManager.Translation.Stretch);
+        AddBinding(imageControl, "Flip", TranslationManager.Translation.Flip);
+        AddBinding(imageControl, "Crop", TranslationManager.Translation.Crop);
+        AddBinding(imageControl, "ChangeBackground", TranslationManager.Translation.ChangeBackground);
+        AddBinding(imageControl, "OptimizeImage", TranslationManager.Translation.OptimizeImage);
+
+        // Interface keys
+        var interfaceConfiguration = keybindings.InterfaceConfigurationKeys.Value;
+        interfaceConfiguration.Clear();
+        AddBinding(interfaceConfiguration, "ToggleInterface", TranslationManager.Translation.HideUI);
+        AddBinding(interfaceConfiguration, "Slideshow", TranslationManager.Translation.Slideshow);
+        AddBinding(interfaceConfiguration, "ToggleGallery", TranslationManager.Translation.ShowImageGallery);
+
+        // File management
+        var fileManagement = keybindings.FileManagementKeys.Value;
+        AddBinding(fileManagement, "Open", TranslationManager.Translation.Open);
+        AddBinding(fileManagement, "OpenWith", TranslationManager.Translation.OpenWith);
+        AddBinding(fileManagement, "Reload", TranslationManager.Translation.Reload);
+        AddBinding(fileManagement, "Save", TranslationManager.Translation.Save);
+        AddBinding(fileManagement, "SaveAs", TranslationManager.Translation.SaveAs);
+        AddBinding(fileManagement, "Print", TranslationManager.Translation.Print);
+        AddBinding(fileManagement, "DeleteFile", TranslationManager.Translation.DeleteFile);
+        AddBinding(fileManagement, "DeleteFilePermanently", TranslationManager.Translation.PermanentlyDelete);
+        AddBinding(fileManagement, "Rename", TranslationManager.Translation.RenameFile);
+        AddBinding(fileManagement, "ShowFileProperties", TranslationManager.Translation.FileProperties);
+        
+        // Sorting
+        var sortFiles = keybindings.SortFilesKeys.Value;
+        AddBinding(sortFiles, "SortFilesByName", TranslationManager.Translation.FileName);
+        AddBinding(sortFiles, "SortFilesBySize", TranslationManager.Translation.FileSize);
+        AddBinding(sortFiles, "SortFilesByExtension", TranslationManager.Translation.FileExtension);
+        AddBinding(sortFiles, "SortFilesByCreationTime", TranslationManager.Translation.Created);
+        AddBinding(sortFiles, "SortFilesByLastAccessTime", TranslationManager.Translation.LastAccessTime);
+        AddBinding(sortFiles, "SortFilesRandomly", TranslationManager.Translation.Random);
+        AddBinding(sortFiles, "SortFilesAscending", TranslationManager.Translation.Ascending);
+        AddBinding(sortFiles, "SortFilesDescending", TranslationManager.Translation.Descending);
+        
+        // Copy
+        var copy = keybindings.CopyKeys.Value;
+        AddBinding(copy, "CopyFile", TranslationManager.Translation.CopyFile);
+        AddBinding(copy, "CopyFilePath", TranslationManager.Translation.FileCopyPath);
+        AddBinding(copy, "CopyImage", TranslationManager.Translation.CopyImage);
+        AddBinding(copy, "CopyBase64", TranslationManager.Translation.Copy + " base64");
+        AddBinding(copy, "Paste", TranslationManager.Translation.FilePaste);
+        AddBinding(copy, "DuplicateFile", TranslationManager.Translation.DuplicateFile);
+        
+        // Tool windows
+        var toolWindows = keybindings.ToolWindowsKeys.Value;
+        AddBinding(toolWindows, "AboutWindow", TranslationManager.Translation.About);
+        AddBinding(toolWindows, "SettingsWindow", TranslationManager.Translation.Settings);
+        AddBinding(toolWindows, "ImageInfoWindow", TranslationManager.Translation.ImageInfo);
+        AddBinding(toolWindows, "ConvertWindow", TranslationManager.Translation.FileConversion);
+        AddBinding(toolWindows, "KeybindingsWindow", TranslationManager.Translation.ApplicationShortcuts);
+        AddBinding(toolWindows, "BatchResizeWindow", TranslationManager.Translation.BatchResize);
+        AddBinding(toolWindows, "ResizeWindow", TranslationManager.Translation.Resize);
+        
+        // Window management
+        var windowManagement = keybindings.WindowManagementKeys.Value;
+        // Special case: Show close as read only
+        windowManagement.Add(new KeyBindingsModel
+        {
+            FriendlyMethodName = TranslationManager.Translation.Close,
+            Key = TranslationManager.Translation.Esc,
+            IsReadOnly = true
+        });
+        AddBinding(windowManagement, "Close", TranslationManager.Translation.Close);
+        AddBinding(windowManagement, "NewWindow", TranslationManager.Translation.NewWindow);
+        AddBinding(windowManagement, "Center", TranslationManager.Translation.CenterWindow);
+        AddBinding(windowManagement, "SetTopMost", TranslationManager.Translation.StayTopMost);
+        // Special case: Show move window as read only
+        windowManagement.Add(new KeyBindingsModel
+        {
+            FriendlyMethodName = TranslationManager.Translation.MoveWindow,
+            Key = $"{TranslationManager.Translation.Shift} + {TranslationManager.Translation.MouseDrag}" ,
+            IsReadOnly = true
+        });
+        AddBinding(windowManagement, "Fullscreen", TranslationManager.Translation.ToggleFullscreen);
+        // TODO: Add minize
+        // AddBinding(windowManagement, "Minimize", TranslationManager.Translation.Minimize);
+        AddBinding(windowManagement, "Maximize", TranslationManager.Translation.Maximize);
+        
+        
+        // Window scaling
+        var windowScaling = keybindings.WindowScalingKeys.Value;
+        AddBinding(windowScaling, "AutoFitWindow", TranslationManager.Translation.AutoFitWindow);
+        AddBinding(windowScaling, "NormalWindow", TranslationManager.Translation.NormalWindow);
+        
+        // Set star rating
+        var starRating = keybindings.StarRatingKeys.Value;
+        AddBinding(starRating, "Set1Star", TranslationManager.Translation._1Star);
+        AddBinding(starRating, "Set2Star", TranslationManager.Translation._2Star);
+        AddBinding(starRating, "Set3Star", TranslationManager.Translation._3Star);
+        AddBinding(starRating, "Set4Star", TranslationManager.Translation._4Star);
+        AddBinding(starRating, "Set5Star", TranslationManager.Translation._5Star);
+        AddBinding(starRating, "Set0Star", TranslationManager.Translation.RemoveStarRating);
+        
+    }
+
+    private static void AddBinding(
+        ObservableCollection<KeyBindingsModel> collection,
+        string methodName,
+        string friendlyName,
+        System.Collections.IEnumerable? customGestures = null,
+        bool isReadOnly = false)
+    {
+        // Use custom gestures if provided, otherwise fetch via method name
+        // Cast<object> ensures we can treat any list type (List<KeyGesture>, etc.) uniformly
+        var gestures = (customGestures ?? GetKeysFromFunction(methodName))?.Cast<object>().ToList();
+        var model = new KeyBindingsModel
+        {
+            MethodName = methodName,
+            FriendlyMethodName = friendlyName,
+            Key = FormatPlus(gestures?.FirstOrDefault()?.ToString() ?? string.Empty),
+            AltKey = FormatPlus(gestures?.LastOrDefault()?.ToString() ?? string.Empty),
+            IsReadOnly = isReadOnly
+        };
+
+        if (!collection.Contains(model))
+        {
+            collection.Add(model);
+        }
+        else
+        {
+            DebugHelper.LogDebug(nameof(FunctionsKeyHelper), nameof(AddBinding),$"Keybinding for {methodName} already exists");
+        }
+    }
+
+}

--- a/src/PicView.Avalonia/Functions/FunctionsKeyHelper.cs
+++ b/src/PicView.Avalonia/Functions/FunctionsKeyHelper.cs
@@ -107,9 +107,9 @@ public static class FunctionsKeyHelper
         
         // Scroll and rotate keys
         var scrollKeys = keybindings.ScrollAndRotateKeys.Value;
-        AddBinding(scrollKeys, "Up", TranslationManager.Translation.RotateRight);
 
         // Special case: ScrollUpInternal is read-only and derived from 'Up' keys
+        AddBinding(scrollKeys, "Up", TranslationManager.Translation.RotateRight);
         var upInternalCheck = KeybindingManager.CustomShortcuts.Where(x => x.Value?.Method?.Name == "Up")
             ?.Select(x => x.Key).ToList() ?? null;
         var scrollUpInternal = new KeyBindingsModel
@@ -121,11 +121,10 @@ public static class FunctionsKeyHelper
             IsReadOnly = true
         };
         keybindings.ScrollAndRotateKeys.Value.Add(scrollUpInternal);
-        
-        AddBinding(scrollKeys, "ScrollUp", TranslationManager.Translation.RotateRight);
-        AddBinding(scrollKeys, "RotateLeft", TranslationManager.Translation.RotateRight);
+        AddBinding(scrollKeys, "ScrollUp", TranslationManager.Translation.ScrollUp);
         
         // Special case: ScrollDownInternal is read-only and derived from 'Down' keys
+        AddBinding(scrollKeys, "Down", TranslationManager.Translation.RotateLeft);
         var downInternalCheck = KeybindingManager.CustomShortcuts.Where(x => x.Value?.Method?.Name == "Down")
             ?.Select(x => x.Key).ToList() ?? null;
         var scrollDownInternal = new KeyBindingsModel
@@ -137,6 +136,9 @@ public static class FunctionsKeyHelper
             IsReadOnly = true
         };
         keybindings.ScrollAndRotateKeys.Value.Add(scrollDownInternal);
+        
+        AddBinding(scrollKeys, "ScrollDown", TranslationManager.Translation.ScrollDown);
+
         
         AddBinding(scrollKeys, "ScrollDown", TranslationManager.Translation.ScrollDown);
         AddBinding(scrollKeys, "ScrollToTop", TranslationManager.Translation.ScrollToTop);

--- a/src/PicView.Avalonia/Functions/FunctionsMapper.cs
+++ b/src/PicView.Avalonia/Functions/FunctionsMapper.cs
@@ -76,9 +76,7 @@ public static class FunctionsMapper
 
             // Scale Window
             "AutoFitWindow" => AutoFitWindow,
-            "AutoFitWindowAndStretch" => AutoFitWindowAndStretch,
             "NormalWindow" => NormalWindow,
-            "NormalWindowAndStretch" => NormalWindowAndStretch,
 
             // Window functions
             "Fullscreen" => Fullscreen,
@@ -493,17 +491,9 @@ public static class FunctionsMapper
     public static async ValueTask AutoFitWindow() =>
         await WindowFunctions.ToggleAutoFit(Vm).ConfigureAwait(false);
 
-    /// <inheritdoc cref="WindowFunctions.AutoFitAndStretch(MainViewModel)" />
-    public static async ValueTask AutoFitWindowAndStretch() =>
-        await WindowFunctions.AutoFitAndStretch(Vm).ConfigureAwait(false);
-
     /// <inheritdoc cref="WindowFunctions.NormalWindow(MainViewModel)" />
     public static async ValueTask NormalWindow() =>
         await WindowFunctions.NormalWindow(Vm).ConfigureAwait(false);
-
-    /// <inheritdoc cref="WindowFunctions.NormalWindowStretch(MainViewModel)" />
-    public static async ValueTask NormalWindowAndStretch() =>
-        await WindowFunctions.NormalWindowStretch(Vm).ConfigureAwait(false);
 
     /// <inheritdoc cref="Interfaces.IPlatformWindowService.ToggleFullscreen" />
     public static async ValueTask ToggleFullscreen() =>

--- a/src/PicView.Avalonia/Input/KeybindingManager.cs
+++ b/src/PicView.Avalonia/Input/KeybindingManager.cs
@@ -82,7 +82,7 @@ public static class KeybindingManager
         }
     }
 
-    internal static void SetDefaultKeybindings(IPlatformSpecificService platformSpecificService)
+    public static void SetDefaultKeybindings(IPlatformSpecificService platformSpecificService)
     {
         if (CustomShortcuts is not null)
         {

--- a/src/PicView.Avalonia/PicViewTheme/Controls/TextBox.axaml
+++ b/src/PicView.Avalonia/PicViewTheme/Controls/TextBox.axaml
@@ -1,7 +1,6 @@
 <ResourceDictionary
     x:ClassModifier="internal"
     xmlns="https://github.com/avaloniaui"
-    xmlns:customControls="clr-namespace:PicView.Avalonia.CustomControls"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <ControlTheme TargetType="TextBox" x:Key="{x:Type TextBox}">
@@ -79,14 +78,14 @@
             </ControlTemplate>
         </Setter>
 
-        <Style Selector="^:pointerover /template/ Border#border">
+        <Style Selector="^:pointerover:not(:readonly) /template/ Border#border">
             <Setter Property="BorderBrush" Value="{DynamicResource SecondaryBorderColor}" />
             <Setter Property="Cursor" Value="IBeam" />
         </Style>
         <Style Selector="^.disabled:pointerover /template/ Border#border">
             <Setter Property="BorderBrush" Value="{TemplateBinding BorderBrush}" />
         </Style>
-        <Style Selector="^:focus /template/ Border#border">
+        <Style Selector="^:focus:not(:readonly) /template/ Border#border">
             <Setter Property="BorderBrush" Value="{DynamicResource AccentColor}" />
         </Style>
         <Style Selector="^.active /template/ Border#border">
@@ -112,6 +111,10 @@
 
         <Style Selector="^.txtShadow /template/ TextPresenter#PART_TextPresenter">
             <Setter Property="Effect" Value="{StaticResource TextShadow}" />
+        </Style>
+
+        <Style Selector="^:readonly /template/ Border#border">
+            <Setter Property="Background" Value="{DynamicResource DisabledBackgroundColor}" />
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/src/PicView.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/PicView.Avalonia/ViewModels/MainViewModel.cs
@@ -29,6 +29,7 @@ public class MainViewModel
     public AboutViewModel? AboutView { get; set; }
     public PrintPreviewViewModel? PrintPreview { get; set; }
     public BatchResizeViewModel? BatchResizeViewModel { get; set; }
+    public KeybindingsViewModel? Keybindings { get; set; }
 
     public MainViewModel(IPlatformSpecificService? platformSpecificService, IPlatformWindowService? platformWindowService)
     {

--- a/src/PicView.Avalonia/Views/Main/KeybindingsView.axaml
+++ b/src/PicView.Avalonia/Views/Main/KeybindingsView.axaml
@@ -14,2093 +14,662 @@
         <viewModels:MainViewModel />
     </Design.DataContext>
 
-    <StackPanel Margin="5,0,2,25">
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            FontSize="16"
-            Margin="10,20,10,15"
-            Text="{CompiledBinding Translation.ApplicationShortcuts.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center"
-            x:Name="ApplicationShortcutsTextBlock" />
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            Text="{CompiledBinding Translation.ChangeKeybindingText.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center"
-            x:Name="ChangeKeybindingTextBlock" />
-        <Button
-            Classes="BorderStyle altHover mainBtn"
-            HorizontalAlignment="Center"
-            Margin="0,15,0,25"
-            x:Name="DefaultButton">
-            <TextBlock Classes="txt" Text="{CompiledBinding Translation.ResetButtonText.Value, Mode=OneWay}" />
-        </Button>
+    <!--  Filter  -->
+    <DockPanel>
 
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            FontSize="14"
-            Margin="10,10,10,15"
-            Text="{CompiledBinding Translation.Navigation.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center"
-            x:Name="NavigationTextBlock" />
+        <Panel DockPanel.Dock="Top" Margin="7,0">
+            <Image
+                Height="14"
+                HorizontalAlignment="Left"
+                Margin="15,0,0,0"
+                Source="{StaticResource SearchImage}"
+                Width="14" />
 
-        <!--  Next image  -->
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.NextImage.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Alt="False"
-                Classes="hover TStyle"
-                MethodName="Next"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Next"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Next 10 images  -->
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.AdvanceBy10Images.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Alt="False"
-                Classes="hover TStyle"
-                MethodName="Next10"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Next10"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Next 100 images  -->
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.AdvanceBy100Images}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Alt="False"
-                Classes="hover TStyle"
-                MethodName="Next100"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Next100"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Previous image  -->
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.PrevImage.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Prev"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Prev"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Previous 10 images  -->
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.GoBackBy10Images.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Alt="False"
-                Classes="hover TStyle"
-                MethodName="Prev10"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Prev10"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Previous 100 images  -->
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.GoBackBy100Images.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Alt="False"
-                Classes="hover TStyle"
-                MethodName="Prev100"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Prev100"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Last image  -->
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.LastImage.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Alt="False"
-                Classes="hover TStyle"
-                MethodName="Last"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Last"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  First image  -->
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.FirstImage.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="First"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="First"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Next folder  -->
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.NextFolder.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Alt="False"
-                Classes="hover TStyle"
-                MethodName="NextFolder"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="NextFolder"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Previous folder  -->
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.PrevFolder.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="PrevFolder"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="PrevFolder"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Search  -->
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Search.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Search"
-                ToolTip.Tip="{CompiledBinding Translation.Search.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Search"
-                ToolTip.Tip="{CompiledBinding Translation.Search.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Select gallery thumb  -->
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.SelectGalleryThumb.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="GalleryClick"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="GalleryClick"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ToggleLooping.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ToggleLooping"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ToggleLooping"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            FontSize="14"
-            Margin="10,10,10,15"
-            Text="{CompiledBinding Translation.ScrollAndRotate.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center" />
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.RotateRight.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Up"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Up"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ScrollUp.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="hover TStyle disabled"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                MethodName="ScrollUpInternal"
-                ToolTip.ServiceEnabled="False"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="hover TStyle disabled"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                MethodName="ScrollUpInternal"
-                ToolTip.ServiceEnabled="False"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ScrollUp.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ScrollUp"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ScrollUp"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.RotateLeft.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Down"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Down"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ScrollDown.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="hover TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                MethodName="ScrollDownInternal"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="hover TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                MethodName="ScrollDownInternal"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ScrollDown.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ScrollDown"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ScrollDown"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ScrollToTop.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ScrollToTop"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ScrollToTop"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ScrollToBottom.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ScrollToBottom"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ScrollToBottom"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ToggleScroll.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ToggleScroll"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ToggleScroll"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.IsCtrlToZoom.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ChangeCtrlZoom"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ChangeCtrlZoom"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            FontSize="14"
-            Margin="10,10,10,15"
-            Text="{CompiledBinding Translation.Zoom.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center" />
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ZoomIn.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ZoomIn"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ZoomIn"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ZoomOut.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ZoomOut"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ZoomOut"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Pan.Value,
-                                       Mode=OneWay}"
-                Width="170" />
             <TextBox
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="hover TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                Text="{CompiledBinding Translation.MouseDrag.Value,
-                                       Mode=OneWay}"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <TextBox
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="hover TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ResetZoom.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ResetZoom"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <TextBox
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="hover TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                Text="{CompiledBinding Translation.DoubleClick.Value,
-                                       Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-
-        <!--  Image control  -->
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            FontSize="14"
-            Margin="10,10,10,15"
-            Text="{CompiledBinding Translation.ImageControl.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center" />
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.SideBySide.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="SideBySide"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="SideBySide"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Stretch.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Stretch"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Stretch"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Flip.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Flip"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Flip"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Crop.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Crop"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Crop"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ChangeBackground.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ChangeBackground"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ChangeBackground"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.OptimizeImage.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="OptimizeImage"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="OptimizeImage"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            FontSize="14"
-            Margin="10,10,10,15"
-            Text="{CompiledBinding Translation.InterfaceConfiguration.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center" />
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.IsShowingUI,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ToggleInterface"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ToggleInterface"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Slideshow.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Slideshow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Slideshow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ShowImageGallery.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ToggleGallery"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ToggleGallery"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            FontSize="14"
-            Margin="10,10,10,15"
-            Text="{CompiledBinding Translation.FileManagement.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center" />
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Open.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Open"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Open"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.OpenWith.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="OpenWith"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="OpenWith"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Reload.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Reload"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Reload"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Save.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Save"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Save"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.SaveAs.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="SaveAs"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="SaveAs"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Print.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Print"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Print"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.DeleteFile.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="DeleteFile"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="DeleteFile"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.PermanentlyDelete.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="DeleteFilePermanently"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="DeleteFilePermanently"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.RenameFile.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Rename"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Rename"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.FileProperties.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ShowFileProperties"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ShowFileProperties"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Sort files  -->
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            FontSize="14"
-            Margin="10,10,10,15"
-            Text="{CompiledBinding Translation.SortFilesBy.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center" />
-
-        <!--  File name  -->
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.FileName.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="SortFilesByName"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="SortFilesByName"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  File size  -->
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.FileSize.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="SortFilesBySize"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="SortFilesBySize"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  File extension  -->
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.FileExtension.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="SortFilesByExtension"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="SortFilesByExtension"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Created  -->
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Created.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="SortFilesByCreationTime"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="SortFilesByCreationTime"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Last access time  -->
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.LastAccessTime.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="SortFilesByLastAccessTime"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="SortFilesByLastAccessTime"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Random  -->
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Random.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="SortFilesRandomly"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="SortFilesRandomly"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Ascending  -->
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Ascending.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="SortFilesAscending"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="SortFilesAscending"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Descending  -->
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Descending.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="SortFilesDescending"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="SortFilesDescending"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <!--  Copy  -->
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            FontSize="14"
-            Margin="10,10,10,15"
-            Text="{CompiledBinding Translation.Copy.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center" />
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.CopyFile.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="CopyFile"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="CopyFile"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.FileCopyPath.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="CopyFilePath"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="CopyFilePath"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.CopyImage.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="CopyImage"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="CopyImage"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Width="170">
-                <Run Text="{CompiledBinding Translation.Copy.Value, Mode=OneWay}" />
-                <Run Text=" base64" />
-            </TextBlock>
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="CopyBase64"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="CopyBase64"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel
-            IsEnabled="False"
-            Margin="15,5,10,10"
-            Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.FileCut.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                MethodName="CutFile"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                MethodName="CutFile"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Paste.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Paste"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Paste"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.DuplicateFile.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="DuplicateFile"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="DuplicateFile"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            FontSize="14"
-            Margin="10,10,10,15"
-            Text="{CompiledBinding Translation.WindowManagement.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center" />
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.About.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="AboutWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="AboutWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Settings.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="SettingsWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="SettingsWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ImageInfo.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ImageInfoWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ImageInfoWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.FileConversion.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ConvertWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ConvertWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ApplicationShortcuts.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="KeybindingsWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="KeybindingsWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.BatchResize.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="BatchResizeWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="BatchResizeWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Resize.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="ResizeWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="ResizeWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Close.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <TextBox
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="hover TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                Width="140"
-                x:Name="CloseBox" />
-            <TextBox
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="hover TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Close.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Close"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Close"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.NewWindow.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="NewWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="NewWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.CenterWindow.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Center"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Center"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.StayTopMost.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="SetTopMost"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="SetTopMost"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.MoveWindow.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <TextBox
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                Width="140"
-                x:Name="DragWindowBox" />
-            <TextBox
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ToggleFullscreen.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Fullscreen"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip,
-                                              Mode=OneWay}"
-                Width="140" />
-            <TextBox
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="hover TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                Width="140"
-                x:Name="FullscreenBox" />
-        </StackPanel>
-
-        <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.ToggleFullscreen.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Fullscreen"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <TextBox
-                Background="{DynamicResource DisabledBackgroundColor}"
-                Classes="hover TStyle"
-                Foreground="{DynamicResource DisabledTextColor}"
-                IsReadOnly="True"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.Maximize.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Maximize"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Maximize"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            FontSize="14"
-            Margin="10,10,10,15"
-            Text="{CompiledBinding Translation.WindowScaling.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center" />
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.AutoFitWindow.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="AutoFitWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="AutoFitWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Width="170">
-                <Run Text="⇔ " />
-                <Run Text="{CompiledBinding Translation.Stretch.Value, Mode=OneWay}" />
-            </TextBlock>
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="AutoFitWindowAndStretch"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="AutoFitWindowAndStretch"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.NormalWindow.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="NormalWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="NormalWindow"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Width="170">
-                <Run Text="⇔ " />
-                <Run Text="{CompiledBinding Translation.Stretch.Value, Mode=OneWay}" />
-            </TextBlock>
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="NormalWindowAndStretch"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="NormalWindowAndStretch"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <TextBlock
-            Classes="txt"
-            FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-            FontSize="14"
-            Margin="10,10,10,15"
-            Text="{CompiledBinding Translation.SetStarRating.Value,
-                                   Mode=OneWay}"
-            TextAlignment="Center" />
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation._1Star.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Set1Star"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Set1Star"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation._2Star.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Set2Star"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Set2Star"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation._3Star.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Set3Star"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Set3Star"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation._4Star.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Set4Star"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Set4Star"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation._5Star.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Set5Star"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Set2Star"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-
-        <StackPanel Margin="15,5,10,10" Orientation="Horizontal">
-            <TextBlock
-                Classes="txt"
-                FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
-                Text="{CompiledBinding Translation.RemoveStarRating.Value,
-                                       Mode=OneWay}"
-                Width="170" />
-            <customControls:KeybindTextBox
-                Classes="hover TStyle"
-                MethodName="Set0Star"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-            <customControls:KeybindTextBox
-                Alt="True"
-                Classes="hover TStyle"
-                MethodName="Set0Star"
-                ToolTip.Tip="{CompiledBinding Translation.ChangeKeybindingTooltip.Value,
-                                              Mode=OneWay}"
-                Width="140" />
-        </StackPanel>
-    </StackPanel>
+                Background="Transparent"
+                BorderBrush="{DynamicResource MainBorderColor}"
+                BorderThickness="1"
+                CornerRadius="4"
+                FontFamily="/Assets/Fonts/Roboto-Regular.ttf#Roboto"
+                Foreground="{DynamicResource MainTextColor}"
+                Padding="50,7,4,7"
+                Text="{CompiledBinding Keybindings.FilterText.Value,
+                                       FallbackValue='',
+                                       Mode=TwoWay}"
+                VerticalAlignment="Center"
+                Watermark="{CompiledBinding Translation.Filter.Value,
+                                            Mode=OneWay}"
+                x:Name="FilterBox" />
+
+            <!--  clear  -->
+            <customControls:IconButton
+                Classes="altHover"
+                Command="{CompiledBinding Keybindings.ClearFilteringCommand}"
+                Data="{StaticResource CloseGeometry}"
+                Foreground="{DynamicResource MainTextColorFaded}"
+                HorizontalAlignment="Right"
+                IconHeight="12"
+                IconWidth="12"
+                IsVisible="{CompiledBinding Keybindings.FilterText.Value,
+                                            Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                Padding="10,3,10,3"
+                x:Name="ClearButton" />
+        </Panel>
+
+        <customControls:AutoScrollViewer>
+
+            <StackPanel>
+
+                <!--  Search  -->
+                <ItemsControl IsVisible="{CompiledBinding Keybindings.IsFiltering.Value}" ItemsSource="{CompiledBinding Keybindings.FilteredKeys.Value}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Margin="15,10,10,10" Orientation="Horizontal">
+                                <TextBlock
+                                    Classes="txt"
+                                    FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                    Text="{CompiledBinding FriendlyMethodName}"
+                                    Width="170" />
+                                <customControls:KeybindTextBox
+                                    Alt="False"
+                                    Classes="hover TStyle"
+                                    IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                 Mode=OneTime}"
+                                    MethodName="{CompiledBinding MethodName}"
+                                    Text="{CompiledBinding Key,
+                                                           Mode=OneTime}"
+                                    ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                  Mode=OneWay}"
+                                    Width="140" />
+                                <customControls:KeybindTextBox
+                                    Alt="True"
+                                    Classes="hover TStyle"
+                                    IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                 Mode=OneTime}"
+                                    MethodName="{CompiledBinding MethodName}"
+                                    Text="{CompiledBinding AltKey,
+                                                           Mode=OneTime}"
+                                    ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                  Mode=OneWay}"
+                                    Width="140" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <!--  Description  -->
+                <StackPanel
+                    IsVisible="{CompiledBinding !Keybindings.IsFiltering.Value}"
+                    Margin="5,0,2,25"
+                    x:Name="MainPanel">
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="16"
+                        Margin="10,20,10,15"
+                        Text="{CompiledBinding Translation.ApplicationShortcuts.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center"
+                        x:Name="ApplicationShortcutsTextBlock" />
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        Text="{CompiledBinding Translation.ChangeKeybindingText.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center"
+                        x:Name="ChangeKeybindingTextBlock" />
+                    <Button
+                        Classes="BorderStyle altHover mainBtn"
+                        Command="{CompiledBinding Keybindings.ResetKeybindingsCommand}"
+                        HorizontalAlignment="Center"
+                        Margin="0,15,0,25"
+                        x:Name="DefaultButton">
+                        <TextBlock Classes="txt" Text="{CompiledBinding Translation.ResetButtonText.Value, Mode=OneWay}" />
+                    </Button>
+
+                    <!--  Navigation  -->
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="14"
+                        Margin="10,10,10,15"
+                        Text="{CompiledBinding Translation.Navigation.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center" />
+                    <ItemsControl ItemsSource="{CompiledBinding Keybindings.NavigationKeys.Value}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
+                                    <TextBlock
+                                        Classes="txt"
+                                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                        Text="{CompiledBinding FriendlyMethodName}"
+                                        Width="170" />
+                                    <customControls:KeybindTextBox
+                                        Alt="False"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding Key,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                    <customControls:KeybindTextBox
+                                        Alt="True"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding AltKey,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!--  Scroll and rotate  -->
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="14"
+                        Margin="10,10,10,15"
+                        Text="{CompiledBinding Translation.ScrollAndRotate.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center" />
+                    <ItemsControl ItemsSource="{CompiledBinding Keybindings.ScrollAndRotateKeys.Value}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
+                                    <TextBlock
+                                        Classes="txt"
+                                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                        Text="{CompiledBinding FriendlyMethodName}"
+                                        Width="170" />
+                                    <customControls:KeybindTextBox
+                                        Alt="False"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding Key,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                    <customControls:KeybindTextBox
+                                        Alt="True"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding AltKey,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!--  Zoom  -->
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="14"
+                        Margin="10,10,10,15"
+                        Text="{CompiledBinding Translation.Zoom.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center" />
+                    <ItemsControl ItemsSource="{CompiledBinding Keybindings.ZoomKeys.Value}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
+                                    <TextBlock
+                                        Classes="txt"
+                                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                        Text="{CompiledBinding FriendlyMethodName}"
+                                        Width="170" />
+                                    <customControls:KeybindTextBox
+                                        Alt="False"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding Key,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                    <customControls:KeybindTextBox
+                                        Alt="True"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding AltKey,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!--  Image control  -->
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="14"
+                        Margin="10,10,10,15"
+                        Text="{CompiledBinding Translation.ImageControl.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center" />
+                    <ItemsControl ItemsSource="{CompiledBinding Keybindings.ImageControlKeys.Value}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
+                                    <TextBlock
+                                        Classes="txt"
+                                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                        Text="{CompiledBinding FriendlyMethodName}"
+                                        Width="170" />
+                                    <customControls:KeybindTextBox
+                                        Alt="False"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding Key,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                    <customControls:KeybindTextBox
+                                        Alt="True"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding AltKey,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!--  Interface configuration  -->
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="14"
+                        Margin="10,10,10,15"
+                        Text="{CompiledBinding Translation.InterfaceConfiguration.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center" />
+                    <ItemsControl ItemsSource="{CompiledBinding Keybindings.InterfaceConfigurationKeys.Value}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
+                                    <TextBlock
+                                        Classes="txt"
+                                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                        Text="{CompiledBinding FriendlyMethodName}"
+                                        Width="170" />
+                                    <customControls:KeybindTextBox
+                                        Alt="False"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding Key,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                    <customControls:KeybindTextBox
+                                        Alt="True"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding AltKey,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!--  File management  -->
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="14"
+                        Margin="10,10,10,15"
+                        Text="{CompiledBinding Translation.FileManagement.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center" />
+                    <ItemsControl ItemsSource="{CompiledBinding Keybindings.FileManagementKeys.Value}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
+                                    <TextBlock
+                                        Classes="txt"
+                                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                        Text="{CompiledBinding FriendlyMethodName}"
+                                        Width="170" />
+                                    <customControls:KeybindTextBox
+                                        Alt="False"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding Key,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                    <customControls:KeybindTextBox
+                                        Alt="True"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding AltKey,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!--  Sort files by  -->
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="14"
+                        Margin="10,10,10,15"
+                        Text="{CompiledBinding Translation.SortFilesBy.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center" />
+                    <ItemsControl ItemsSource="{CompiledBinding Keybindings.SortFilesKeys.Value}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
+                                    <TextBlock
+                                        Classes="txt"
+                                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                        Text="{CompiledBinding FriendlyMethodName}"
+                                        Width="170" />
+                                    <customControls:KeybindTextBox
+                                        Alt="False"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding Key,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                    <customControls:KeybindTextBox
+                                        Alt="True"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding AltKey,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+
+                    <!--  Copy  -->
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="14"
+                        Margin="10,10,10,15"
+                        Text="{CompiledBinding Translation.Copy.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center" />
+                    <ItemsControl ItemsSource="{CompiledBinding Keybindings.CopyKeys.Value}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
+                                    <TextBlock
+                                        Classes="txt"
+                                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                        Text="{CompiledBinding FriendlyMethodName}"
+                                        Width="170" />
+                                    <customControls:KeybindTextBox
+                                        Alt="False"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding Key,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                    <customControls:KeybindTextBox
+                                        Alt="True"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding AltKey,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!--  Tool Windows  -->
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="14"
+                        Margin="10,10,10,15"
+                        Text="{CompiledBinding Translation.ToolWindows.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center" />
+                    <ItemsControl ItemsSource="{CompiledBinding Keybindings.ToolWindowsKeys.Value}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
+                                    <TextBlock
+                                        Classes="txt"
+                                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                        Text="{CompiledBinding FriendlyMethodName}"
+                                        Width="170" />
+                                    <customControls:KeybindTextBox
+                                        Alt="False"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding Key,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                    <customControls:KeybindTextBox
+                                        Alt="True"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding AltKey,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!--  Window management  -->
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="14"
+                        Margin="10,10,10,15"
+                        Text="{CompiledBinding Translation.WindowManagement.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center" />
+                    <ItemsControl ItemsSource="{CompiledBinding Keybindings.WindowManagementKeys.Value}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
+                                    <TextBlock
+                                        Classes="txt"
+                                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                        Text="{CompiledBinding FriendlyMethodName}"
+                                        Width="170" />
+                                    <customControls:KeybindTextBox
+                                        Alt="False"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding Key,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                    <customControls:KeybindTextBox
+                                        Alt="True"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding AltKey,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!--  Window scaling  -->
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="14"
+                        Margin="10,10,10,15"
+                        Text="{CompiledBinding Translation.WindowScaling.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center" />
+                    <ItemsControl ItemsSource="{CompiledBinding Keybindings.WindowScalingKeys.Value}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
+                                    <TextBlock
+                                        Classes="txt"
+                                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                        Text="{CompiledBinding FriendlyMethodName}"
+                                        Width="170" />
+                                    <customControls:KeybindTextBox
+                                        Alt="False"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding Key,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                    <customControls:KeybindTextBox
+                                        Alt="True"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding AltKey,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!--  Set star rating  -->
+                    <TextBlock
+                        Classes="txt"
+                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                        FontSize="14"
+                        Margin="10,10,10,15"
+                        Text="{CompiledBinding Translation.SetStarRating.Value,
+                                               Mode=OneWay}"
+                        TextAlignment="Center" />
+                    <ItemsControl ItemsSource="{CompiledBinding Keybindings.StarRatingKeys.Value}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="15,0,10,10" Orientation="Horizontal">
+                                    <TextBlock
+                                        Classes="txt"
+                                        FontFamily="/Assets/Fonts/Roboto-Bold.ttf#Roboto"
+                                        Text="{CompiledBinding FriendlyMethodName}"
+                                        Width="170" />
+                                    <customControls:KeybindTextBox
+                                        Alt="False"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding Key,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                    <customControls:KeybindTextBox
+                                        Alt="True"
+                                        Classes="hover TStyle"
+                                        IsReadOnly="{CompiledBinding IsReadOnly,
+                                                                     Mode=OneTime}"
+                                        MethodName="{CompiledBinding MethodName}"
+                                        Text="{CompiledBinding AltKey,
+                                                               Mode=OneTime}"
+                                        ToolTip.Tip="{CompiledBinding #MainPanel.((viewModels:MainViewModel)DataContext).Translation.ChangeKeybindingTooltip.Value,
+                                                                      Mode=OneWay}"
+                                        Width="140" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                </StackPanel>
+            </StackPanel>
+        </customControls:AutoScrollViewer>
+    </DockPanel>
 </UserControl>

--- a/src/PicView.Avalonia/Views/Main/KeybindingsView.axaml.cs
+++ b/src/PicView.Avalonia/Views/Main/KeybindingsView.axaml.cs
@@ -1,11 +1,4 @@
-using System.Runtime.InteropServices;
 using Avalonia.Controls;
-using Avalonia.Media;
-using Avalonia.Threading;
-using PicView.Avalonia.Functions;
-using PicView.Avalonia.Input;
-using PicView.Avalonia.ViewModels;
-using PicView.Core.Localization;
 
 namespace PicView.Avalonia.Views.Main;
 
@@ -14,46 +7,5 @@ public partial class KeybindingsView : UserControl
     public KeybindingsView()
     {
         InitializeComponent();
-        DefaultButton.Click += async delegate { await SetDefault(); };
-        FullscreenBox.Text = $"{TranslationManager.Translation.Shift} + {TranslationManager.Translation.DoubleClick}";
-        FullscreenBox.Text = $"{TranslationManager.Translation.Shift} + {TranslationManager.Translation.DoubleClick}";
-        DragWindowBox.Text = $"{TranslationManager.Translation.Shift} + {TranslationManager.Translation.MouseDrag}";
-        CloseBox.Text = TranslationManager.Translation.Esc;
-        
-        // Fix invisible text on macOS
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            ApplicationShortcutsTextBlock.TextAlignment = TextAlignment.Left;
-            ChangeKeybindingTextBlock.TextAlignment = TextAlignment.Left;
-            NavigationTextBlock.TextAlignment = TextAlignment.Left;
-
-            Loaded += delegate
-            {
-                ApplicationShortcutsTextBlock.TextAlignment = TextAlignment.Center;
-                ChangeKeybindingTextBlock.TextAlignment = TextAlignment.Center;
-                NavigationTextBlock.TextAlignment = TextAlignment.Center;
-            };
-        }
-    }
-
-    private async Task SetDefault()
-    {
-        if (DataContext is not MainViewModel vm)
-        {
-            return;
-        }
-
-        KeybindingManager.SetDefaultKeybindings(vm.PlatformService);
-        await Dispatcher.UIThread.InvokeAsync(() =>
-        {
-            var topLevel = TopLevel.GetTopLevel(this);
-            if (topLevel is not Window window)
-            {
-                return;
-            }
-            window.Close();
-        });
-
-        await FunctionsMapper.KeybindingsWindow();
     }
 }

--- a/src/PicView.Core/Models/KeyBindingsModel.cs
+++ b/src/PicView.Core/Models/KeyBindingsModel.cs
@@ -1,0 +1,36 @@
+namespace PicView.Core.Models;
+
+public struct KeyBindingsModel
+{
+    public KeyBindingsModel(string friendlyMethodName, string methodName, string key, string altKey)
+    {
+        FriendlyMethodName = friendlyMethodName;
+        MethodName = methodName;
+        Key = key;
+        AltKey = altKey;
+    }
+
+    /// <summary>
+    /// The translated name of the method.
+    /// <remarks>Used for display in the UI.</remarks>
+    /// </summary>
+    public string? FriendlyMethodName { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// The name of the method to invoke when the key combination is pressed.
+    /// <remarks>Used as identifier for the dictionary</remarks>
+    /// </summary>
+    public string? MethodName { get; set; } = string.Empty;
+    /// <summary>
+    /// The key combination to invoke the method.
+    /// <remarks>Used for display in the UI.</remarks>
+    /// </summary>
+    public string? Key { get; set; } = string.Empty;
+    /// <summary>
+    /// The key combination to invoke for the alternative method.
+    /// <remarks>Used for display in the UI.</remarks>
+    /// </summary>
+    public string? AltKey { get; set; } = string.Empty;
+    
+    public bool IsReadOnly { get; init; } = false;
+}

--- a/src/PicView.Core/ViewModels/KeybindingsViewModel.cs
+++ b/src/PicView.Core/ViewModels/KeybindingsViewModel.cs
@@ -1,0 +1,113 @@
+using System.Collections.ObjectModel;
+using PicView.Core.Models;
+using R3;
+
+namespace PicView.Core.ViewModels;
+
+public class KeybindingsViewModel : IDisposable
+{
+    private readonly CompositeDisposable _disposables = new();
+    
+    public BindableReactiveProperty<string> FilterText { get; } = new(string.Empty);
+    public BindableReactiveProperty<bool> IsFiltering { get; } = new();
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> FilteredKeys { get; } = new([]);
+    public ReactiveCommand? ClearFilteringCommand { get; }
+    
+    public ReactiveCommand? ResetKeybindingsCommand { get; set; }
+    
+    
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> NavigationKeys { get; } = new([]);
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> ScrollAndRotateKeys { get; } = new([]);
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> ZoomKeys { get; } = new([]);
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> ImageControlKeys { get; } = new([]);
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> InterfaceConfigurationKeys { get; } = new([]);
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> FileManagementKeys { get; } = new([]);
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> SortFilesKeys { get; } = new([]);
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> CopyKeys { get; } = new([]);
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> ToolWindowsKeys { get; } = new([]);
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> WindowManagementKeys { get; } = new([]);
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> WindowScalingKeys { get; } = new([]);
+    public BindableReactiveProperty<ObservableCollection<KeyBindingsModel>> StarRatingKeys { get; } = new([]);
+
+    public KeybindingsViewModel()
+    {
+       Observable.EveryValueChanged(FilterText, _ => IsFiltering.Value = !string.IsNullOrWhiteSpace(FilterText.Value))
+           .Subscribe(x => { }).AddTo(_disposables);
+       
+       // Subscribe to FilterText changes to update FilteredKeys
+       FilterText
+           .Subscribe(filterText =>
+           {
+               FilteredKeys.Value.Clear();
+               
+               if (string.IsNullOrWhiteSpace(filterText))
+               {
+                   return;
+               }
+               
+               // Get all keybinding collections
+               var allCollections = new[]
+               {
+                   NavigationKeys.Value,
+                   ScrollAndRotateKeys.Value,
+                   ZoomKeys.Value,
+                   ImageControlKeys.Value,
+                   InterfaceConfigurationKeys.Value,
+                   FileManagementKeys.Value,
+                   SortFilesKeys.Value,
+                   CopyKeys.Value,
+                   ToolWindowsKeys.Value,
+                   WindowManagementKeys.Value,
+                   WindowScalingKeys.Value,
+                   StarRatingKeys.Value
+               };
+               
+               // Search through all collections and add matches
+               foreach (var collection in allCollections)
+               {
+                   foreach (var binding in collection)
+                   {
+                       if (MatchesFilter(binding, filterText))
+                       {
+                           FilteredKeys.Value.Add(binding);
+                       }
+                   }
+               }
+           })
+           .AddTo(_disposables);
+       
+       ClearFilteringCommand = new ReactiveCommand(_ => { FilterText.Value = string.Empty; });
+       
+       _disposables.Add(FilteredKeys);
+       _disposables.Add(NavigationKeys);
+       _disposables.Add(ScrollAndRotateKeys);
+       _disposables.Add(ZoomKeys);
+       _disposables.Add(ImageControlKeys);
+       _disposables.Add(InterfaceConfigurationKeys);
+       _disposables.Add(FileManagementKeys);
+       _disposables.Add(SortFilesKeys);
+       _disposables.Add(CopyKeys);
+       _disposables.Add(ToolWindowsKeys);
+       _disposables.Add(WindowManagementKeys);
+       _disposables.Add(WindowScalingKeys);
+       _disposables.Add(StarRatingKeys);
+    }
+    
+    private static bool MatchesFilter(KeyBindingsModel binding, string searchTerm)
+    {
+        // Search in friendly name, method name, key, and alt key
+        return (binding.FriendlyMethodName?.Contains(searchTerm, StringComparison.InvariantCultureIgnoreCase) ?? false) ||
+               (binding.MethodName?.Contains(searchTerm, StringComparison.InvariantCultureIgnoreCase) ?? false) ||
+               (binding.Key?.Contains(searchTerm, StringComparison.InvariantCultureIgnoreCase) ?? false) ||
+               (binding.AltKey?.Contains(searchTerm, StringComparison.InvariantCultureIgnoreCase) ?? false);
+    }
+
+    
+    
+    public void Dispose()
+    {
+        _disposables.Dispose();
+        
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
## Description
Refactored the keybinding system to include a new `KeybindingsViewModel` for managing keybinding configurations and their resetting. The changes also include filtering keybindings, and updates to enhance focus handling and read-only behavior of `KeybindTextBox`. Introduced utility logic for keybinding management via `FunctionsKeyHelper` and removed functions related to window scaling from `FunctionsMapper`. 

## Motivation and Context
Allow users to search for keybindings in the view. Should be more maintainable with a viewodel.

## How Has This Been Tested?
Only on macOS, needs Windows testing.

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.