### PR TITLE
Fix Multiple Bugs in Crop Functionality

### DIFF
--- a/src/PicView.Avalonia/Crop/CropLayoutManager.cs
+++ b/src/PicView.Avalonia/Crop/CropLayoutManager.cs
@@ -8,7 +8,7 @@ namespace PicView.Avalonia.Crop;
 public class CropLayoutManager(CropControl control)
 {
     private const int DefaultSelectionSize = 200;
-    
+
     public void InitializeLayout()
     {
         if (control.DataContext is not MainViewModel vm)
@@ -23,19 +23,15 @@ public class CropLayoutManager(CropControl control)
         }
 
         // Set initial width and height for the crop rectangle
-        var pixelWidth = vm.PicViewer.ImageWidth.CurrentValue / vm.PicViewer.AspectRatio.CurrentValue;
-        var pixelHeight = vm.PicViewer.ImageHeight.CurrentValue / vm.PicViewer.AspectRatio.CurrentValue;
+        var origionalWidth = vm.PicViewer.ImageWidth.CurrentValue >= DefaultSelectionSize * 2
+            ? DefaultSelectionSize
+            : (uint)(vm.PicViewer.ImageWidth.CurrentValue / 2);
+        var origionalHeight = vm.PicViewer.ImageHeight.CurrentValue >= DefaultSelectionSize * 2
+            ? DefaultSelectionSize
+            : (uint)(vm.PicViewer.ImageHeight.CurrentValue / 2);
 
-        if (pixelWidth >= DefaultSelectionSize * 2 || pixelHeight >= DefaultSelectionSize * 2)
-        {
-            vm.Crop.SetSelectionWidth(DefaultSelectionSize);
-            vm.Crop.SetSelectionHeight(DefaultSelectionSize);
-        }
-        else if (pixelWidth <= DefaultSelectionSize || pixelHeight <= DefaultSelectionSize)
-        {
-            vm.Crop.SetSelectionWidth((uint)(pixelWidth / 2));
-            vm.Crop.SetSelectionHeight((uint)(pixelHeight / 2));
-        }
+        vm.Crop.SetSelectionWidth(origionalWidth);
+        vm.Crop.SetSelectionHeight(origionalHeight);
 
         // Calculate centered position
         vm.Crop.SelectionX.Value = Convert.ToInt32((vm.PicViewer.ImageWidth.CurrentValue - vm.Crop.SelectionWidth.CurrentValue) / 2);
@@ -202,14 +198,6 @@ public class CropLayoutManager(CropControl control)
         Canvas.SetTop(control.RightMiddleButton, rightMiddleY);
 
         Canvas.SetLeft(control.SizeBorder, topLeftX + control.TopLeftButton.Bounds.Width + 2);
-
-        if (topLeftY != 0)
-        {
-            Canvas.SetTop(control.SizeBorder, topLeftY - control.TopLeftButton.Bounds.Height);
-        }
-        else
-        {
-            Canvas.SetTop(control.SizeBorder, topLeftY);
-        }
+        Canvas.SetTop(control.SizeBorder, Math.Max(0, topLeftY - control.TopLeftButton.Bounds.Height));
     }
 }

--- a/src/PicView.Avalonia/Crop/CropLayoutManager.cs
+++ b/src/PicView.Avalonia/Crop/CropLayoutManager.cs
@@ -23,15 +23,15 @@ public class CropLayoutManager(CropControl control)
         }
 
         // Set initial width and height for the crop rectangle
-        var origionalWidth = vm.PicViewer.ImageWidth.CurrentValue >= DefaultSelectionSize * 2
+        var originalWidth = vm.PicViewer.ImageWidth.CurrentValue >= DefaultSelectionSize * 2
             ? DefaultSelectionSize
             : (uint)(vm.PicViewer.ImageWidth.CurrentValue / 2);
-        var origionalHeight = vm.PicViewer.ImageHeight.CurrentValue >= DefaultSelectionSize * 2
+        var originalHeight = vm.PicViewer.ImageHeight.CurrentValue >= DefaultSelectionSize * 2
             ? DefaultSelectionSize
             : (uint)(vm.PicViewer.ImageHeight.CurrentValue / 2);
 
-        vm.Crop.SetSelectionWidth(origionalWidth);
-        vm.Crop.SetSelectionHeight(origionalHeight);
+        vm.Crop.SetSelectionWidth(originalWidth);
+        vm.Crop.SetSelectionHeight(originalHeight);
 
         // Calculate centered position
         vm.Crop.SelectionX.Value = Convert.ToInt32((vm.PicViewer.ImageWidth.CurrentValue - vm.Crop.SelectionWidth.CurrentValue) / 2);

--- a/src/PicView.Avalonia/Crop/CropResizer.cs
+++ b/src/PicView.Avalonia/Crop/CropResizer.cs
@@ -15,13 +15,13 @@ public static class CropResizer
     {
         var currentPos = e.GetPosition(control.RootCanvas);
         var delta = currentPos - resizeStart;
-        
+
         // Initialize with original values
         var newX = originalRect.X;
         var newY = originalRect.Y;
         var newWidth = originalRect.Width;
         var newHeight = originalRect.Height;
-        
+
         // Calculate new dimensions based on resize mode
         switch (mode)
         {
@@ -31,49 +31,49 @@ public static class CropResizer
                 newWidth -= delta.X;
                 newHeight -= delta.Y;
                 break;
-                
+
             case CropResizeMode.TopRight:
                 newY += delta.Y;
                 newWidth += delta.X;
                 newHeight -= delta.Y;
                 break;
-                
+
             case CropResizeMode.BottomLeft:
                 newX += delta.X;
                 newWidth -= delta.X;
                 newHeight += delta.Y;
                 break;
-                
+
             case CropResizeMode.BottomRight:
                 newWidth += delta.X;
                 newHeight += delta.Y;
                 break;
-                
+
             case CropResizeMode.Left:
                 newX += delta.X;
                 newWidth -= delta.X;
                 break;
-                
+
             case CropResizeMode.Right:
                 newWidth += delta.X;
                 break;
-                
+
             case CropResizeMode.Top:
                 newY += delta.Y;
                 newHeight -= delta.Y;
                 break;
-                
+
             case CropResizeMode.Bottom:
                 newHeight += delta.Y;
                 break;
         }
-        
+
         // Handle aspect ratio constraints (maintain square when Shift is pressed)
         if (MainKeyboardShortcuts.ShiftDown && IsCornerMode(mode))
         {
             // Use the larger dimension to determine square size
             var size = Math.Max(newWidth, newHeight);
-            
+
             // Adjust position based on resize mode to maintain the correct anchor point
             switch (mode)
             {
@@ -81,23 +81,23 @@ public static class CropResizer
                     newX = originalRect.X + originalRect.Width - size;
                     newY = originalRect.Y + originalRect.Height - size;
                     break;
-                    
+
                 case CropResizeMode.TopRight:
                     newY = originalRect.Y + originalRect.Height - size;
                     break;
-                    
+
                 case CropResizeMode.BottomLeft:
                     newX = originalRect.X + originalRect.Width - size;
                     break;
             }
-            
+
             newWidth = size;
             newHeight = size;
         }
-        
+
         // Apply bounds constraints
         ApplyBoundsConstraints(ref newX, ref newY, ref newWidth, ref newHeight, vm.ImageWidth.CurrentValue, vm.ImageHeight.CurrentValue);
-        
+
         // Update the view model
         try
         {
@@ -110,18 +110,18 @@ public static class CropResizer
         {
             DebugHelper.LogDebug(nameof(CropResizer), nameof(Resize), exception);
         }
-        
+
         // Update the rectangle position on canvas
         Canvas.SetLeft(control.MainRectangle, newX);
         Canvas.SetTop(control.MainRectangle, newY);
     }
-    
-    private static bool IsCornerMode(CropResizeMode mode) => mode is 
-        CropResizeMode.TopLeft or 
-        CropResizeMode.TopRight or 
-        CropResizeMode.BottomLeft or 
+
+    private static bool IsCornerMode(CropResizeMode mode) => mode is
+        CropResizeMode.TopLeft or
+        CropResizeMode.TopRight or
+        CropResizeMode.BottomLeft or
         CropResizeMode.BottomRight;
-        
+
     private static void ApplyBoundsConstraints(ref double x, ref double y, ref double width, ref double height, double maxWidth, double maxHeight)
     {
         // Ensure we don't go beyond canvas bounds
@@ -130,23 +130,33 @@ public static class CropResizer
             width += x;
             x = 0;
         }
-        
+
         if (y < 0)
         {
             height += y;
             y = 0;
         }
-        
+
+        if (x >= maxWidth)
+        {
+            x = maxWidth - 1;
+        }
+
+        if (y >= maxHeight)
+        {
+            y = maxHeight - 1;
+        }
+
         // Ensure minimum dimensions
         width = Math.Max(width, 1);
         height = Math.Max(height, 1);
-        
+
         // Ensure we don't exceed the canvas bounds
         if (x + width > maxWidth)
         {
             width = maxWidth - x;
         }
-        
+
         if (y + height > maxHeight)
         {
             height = maxHeight - y;

--- a/src/PicView.Avalonia/Views/UC/CropControl.axaml
+++ b/src/PicView.Avalonia/Views/UC/CropControl.axaml
@@ -3,7 +3,8 @@
     x:DataType="viewModels:MainViewModel"
     xmlns="https://github.com/avaloniaui"
     xmlns:viewModels="clr-namespace:PicView.Avalonia.ViewModels"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    ClipToBounds="False">
     <UserControl.Resources>
         <SolidColorBrush Color="{DynamicResource MainTextColor}" x:Key="Brush0" />
     </UserControl.Resources>


### PR DESCRIPTION
## Description

While using PicView's "Crop" feature, I encountered several bugs and have attempted to fix them in this PR. Here is a brief introduction to the issues:

**1. TextBlock Overlap at Top Edge:**
When the crop area is close to the top edge of the window, the TextBlock displaying the crop dimensions is partially covered, making the values hard to read.

<img width="307" height="74" alt="image" src="https://github.com/user-attachments/assets/bc419d37-3285-4ef6-ae21-00ce4a768e0d" />

**2. TextBlock Overlap at Right Edge:**
When the crop area is close to the right side of the image, the TextBlock is also partially covered, making it impossible to view the values.

<img width="206" height="103" alt="image" src="https://github.com/user-attachments/assets/9e086b03-f127-42d1-bb8d-aeba1f3084d8" />

**3. Incorrect Initial Crop Size for Small Images:**
For images with small dimensions, the initial crop area size is incorrect. For example, after clicking the crop button, the initial width may be 537, while the image itself is only 300 pixels wide. At the same time, in the incorrect case, the crop area’s left and right borders are not visible, as they are clipped outside the image bounds.

<img width="369" height="284" alt="image" src="https://github.com/user-attachments/assets/561f346e-9cb3-4326-9e55-c40f0265bab4" />

Comparing the two pictures above and below, it is clear that the left and right boundaries of the cropped area in the top picture (the white line) are not visible.

<img width="448" height="349" alt="image" src="https://github.com/user-attachments/assets/9789d408-915b-4477-8887-6ab1fbd99fd8" />

**4. Crop Area Size is (0, 0) for Certain Resolutions:**
For images within a specific resolution range, the default crop area size is set to (0, 0).

<img width="215" height="97" alt="image" src="https://github.com/user-attachments/assets/9c1bc6a6-0a59-4dcb-bfb5-a5112d8dbfe2" />

## Bug Analysis and Fixes:

**1. Top Edge Overlap:**

The calculation for the TextBlock position only handled the case when `topLeftY == 0`, ignoring the thickness of the TextBlock itself.
Original code:
```csharp
if (topLeftY != 0)
{
    Canvas.SetTop(control.SizeBorder, topLeftY - control.TopLeftButton.Bounds.Height);
}
else
{
    Canvas.SetTop(control.SizeBorder, topLeftY);
}
```
**Fix:**

Update to:

```csharp
Canvas.SetTop(control.SizeBorder, Math.Max(0, topLeftY - control.TopLeftButton.Bounds.Height));
```

This ensures the TextBlock is always visible.
![PicView_FDxDVnkzsH](https://github.com/user-attachments/assets/92953bd4-2571-4762-bca5-fbc7dee65dce)

**2. Right Edge Overlap:**
For large images, you can calculate the TextBlock width and adjust its left position using SetLeft. However, for very small images, the TextBlock will inevitably be clipped. Therefore, I suggest changing the parent container’s ClipToBounds property to False:

```xml
ClipToBounds="False"
```
<img width="300" height="138" alt="image" src="https://github.com/user-attachments/assets/696b37c0-2b34-4dfc-89c4-cdfde14a0406" />

**3 & 4. Incorrect Initial Crop Size:**

These bugs are due to incomplete logic in CropLayoutManager initialization.

Original code:
```csharp

   var pixelWidth = vm.PicViewer.ImageWidth.CurrentValue / vm.PicViewer.AspectRatio.CurrentValue;
   var pixelHeight = vm.PicViewer.ImageHeight.CurrentValue / vm.PicViewer.AspectRatio.CurrentValue;
   if (pixelWidth >= DefaultSelectionSize * 2 &&
       pixelHeight >= DefaultSelectionSize * 2)
   {
       vm.Crop.SetSelectionWidth(DefaultSelectionSize);
       vm.Crop.SetSelectionHeight(DefaultSelectionSize);
   }
   else if (pixelWidth <= DefaultSelectionSize &&
            pixelHeight <= DefaultSelectionSize)
   {
       vm.Crop.SetSelectionWidth((uint)(pixelWidth / 2));
       vm.Crop.SetSelectionHeight((uint)(pixelHeight / 2));
   }

```
Problems:

When DefaultSelectionSize < pixelWidth < DefaultSelectionSize * 2, there is no logic, resulting in crop area width/height being zero.

Since the current DefaultSelectionSize is set to 200, if an image has a resolution between 200 and 400 (for example, 350 × 350), this will trigger the bug where the initial crop area size is zero.

The crop size should be based on ImageWidth, not pixelWidth. For example, if pixelWidth = 300 but the displayed ImageWidth is only 118 due to scaling, the initial crop width should not exceed 118 / 2.

**Fix:**
```csharp

   var originalWidth = vm.PicViewer.ImageWidth.CurrentValue >= DefaultSelectionSize * 2
       ? DefaultSelectionSize
       : (uint)(vm.PicViewer.ImageWidth.CurrentValue / 2);
   var originalHeight = vm.PicViewer.ImageHeight.CurrentValue >= DefaultSelectionSize * 2
       ? DefaultSelectionSize
       : (uint)(vm.PicViewer.ImageHeight.CurrentValue / 2);
   vm.Crop.SetSelectionWidth(originalWidth);
   vm.Crop.SetSelectionHeight(originalHeight);

```

<img width="312" height="342" alt="image" src="https://github.com/user-attachments/assets/9d664aed-f7f5-45d2-941f-e4fef4079f77" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Maybe this can only be tested manually?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
