### PR TITLE
[codex] Fix embedded ICC profile rendering

### DIFF
--- a/src/PicView.Avalonia/ImageHandling/GetImage.cs
+++ b/src/PicView.Avalonia/ImageHandling/GetImage.cs
@@ -34,6 +34,7 @@ public static class GetImage
 
         // Rotate image according to EXIF orientation
         magickImage.AutoOrient();
+        TransformToSrgbIfNeeded(magickImage);
 
         var bitmap = magickImage.ToWriteableBitmap();
         if (shouldDisposeMagickImage)
@@ -56,6 +57,7 @@ public static class GetImage
 
         // Rotate image according to EXIF orientation
         magickImage.AutoOrient();
+        TransformToSrgbIfNeeded(magickImage);
 
         var bitmap = magickImage.ToWriteableBitmap();
         if (shouldDisposeMagickImage)
@@ -85,6 +87,7 @@ public static class GetImage
 
         // Rotate image according to EXIF orientation
         magickImage.AutoOrient();
+        TransformToSrgbIfNeeded(magickImage);
 
         var bitmap = magickImage.ToWriteableBitmap();
         magickImage.Dispose();
@@ -96,5 +99,22 @@ public static class GetImage
         var magickImage = new MagickImage();
         magickImage.Ping(fileInfo);
         return magickImage;
+    }
+
+    internal static void TransformToSrgbIfNeeded(MagickImage magickImage)
+    {
+        if (magickImage.GetColorProfile() is null)
+        {
+            return;
+        }
+
+        try
+        {
+            magickImage.TransformColorSpace(ColorProfiles.SRGB);
+        }
+        catch (Exception e)
+        {
+            DebugHelper.LogDebug(nameof(GetImage), nameof(TransformToSrgbIfNeeded), e);
+        }
     }
 }

--- a/src/PicView.Avalonia/ImageHandling/GetImageModel.cs
+++ b/src/PicView.Avalonia/ImageHandling/GetImageModel.cs
@@ -42,6 +42,7 @@ public static class GetImageModel
             // Check if rotation is needed
             var orientation = ExifOrientationHelper.GetImageOrientation(magickImage);
             var shouldAutoOrient = orientation is not (ExifOrientation.None or ExifOrientation.Horizontal);
+            var shouldColorManage = HasNonSrgbColorProfile(magickImage);
             
             if (fileInfo.Extension.Equals(".b64", StringComparison.InvariantCultureIgnoreCase))
             {
@@ -104,7 +105,7 @@ public static class GetImageModel
                 case MagickFormat.Ico:
                 case MagickFormat.Icon:
                 case MagickFormat.Wbmp:
-                    if (shouldAutoOrient)
+                    if (shouldAutoOrient || shouldColorManage)
                     {
                         await ProcessNonStandardImageAsync(fileInfo, imageModel, magickImage).ConfigureAwait(false);
                     }
@@ -178,6 +179,17 @@ public static class GetImageModel
             PixelHeight = 0,
             PixelWidth = 0
         };
+    }
+
+    private static bool HasNonSrgbColorProfile(MagickImage magickImage)
+    {
+        var colorProfile = magickImage.GetColorProfile();
+        if (colorProfile is null)
+        {
+            return false;
+        }
+
+        return colorProfile.Description?.Contains("sRGB", StringComparison.OrdinalIgnoreCase) != true;
     }
 
     #region Image Processing Methods


### PR DESCRIPTION
## Summary

- Convert Magick-loaded images with embedded non-sRGB ICC profiles to sRGB before creating Avalonia `WriteableBitmap` instances.
- Route common still images with embedded non-sRGB profiles through the Magick.NET loading path so the profile can be honored.
- Keep the existing fast path for images without embedded profiles or with already-sRGB profiles.

## Why This Is Needed

Some phone photos embed a wide-gamut ICC profile such as Display P3 even when their EXIF `ColorSpace` value reports sRGB. PicView's common still-image fast path decoded those files through Avalonia/Skia without checking the embedded ICC profile. Magick.NET-backed paths also copied RGBA pixels into Avalonia bitmaps without first normalizing the embedded profile to sRGB.

On render targets that do not apply that ICC transform later, the wide-gamut pixel values are treated as if they were already sRGB. The visible result is that affected photos look flatter, grayer, or less saturated than they do in color-managed viewers such as Chrome or XnView.

## What This Fixes

- Detects embedded non-sRGB color profiles before choosing the image loading path.
- Sends those still images through the Magick.NET path where profile conversion is available.
- Transforms embedded profiles to sRGB before creating Avalonia `WriteableBitmap` instances.
- Applies the same conversion to existing Magick-backed paths used for EXIF auto-orientation, RAW/base64, and less common image loading.

## Validation

- Built `src/PicView.Avalonia.Win32/PicView.Avalonia.Win32.csproj` with .NET `11.0.100-preview.5.26302.115`:
  `dotnet build src/PicView.Avalonia.Win32/PicView.Avalonia.Win32.csproj -c Debug -p:Platform=x64 --no-restore`
- Manually checked a Display P3 JPEG sample and confirmed the rendered color now matches Chrome/XnView more closely.