### PR TITLE
Fix EXIF UserComment encoding for non-ASCII comments

### DIFF
--- a/src/PicView.Core/Exif/ExifReader.cs
+++ b/src/PicView.Core/Exif/ExifReader.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Text;
 using ImageMagick;
 using PicView.Core.Localization;
@@ -389,14 +389,21 @@ public static class ExifReader
 
         try
         {
-            var decodedComment = Encoding.ASCII.GetString(commentBytes);
-            if (string.IsNullOrWhiteSpace(decodedComment))
-            {
-                return string.Empty;
-            }
+            // The first 8 bytes of an EXIF UserComment identify the character
+            // encoding ("ASCII", "UNICODE", "JIS", or NULs when undefined).
+            var header = Encoding.ASCII.GetString(commentBytes, 0, 8).TrimEnd('\0');
+            var textBytes = commentBytes[8..];
 
-            var result = decodedComment.StartsWith("UNICODE") ? decodedComment.Replace("UNICODE", "") : decodedComment;
-            return result.StartsWith("ASCII") ? string.Empty : result;
+            var result = header switch
+            {
+                "ASCII" => Encoding.ASCII.GetString(textBytes),
+                "UNICODE" => Encoding.Unicode.GetString(textBytes),
+                "JIS" => Encoding.UTF8.GetString(textBytes),
+                _ => Encoding.UTF8.GetString(textBytes)
+            };
+
+            result = result.TrimEnd('\0').TrimEnd();
+            return string.IsNullOrWhiteSpace(result) ? string.Empty : result;
         }
         catch (Exception)
         {


### PR DESCRIPTION
Fixes #324

## Root cause

`GetUserComment` decoded the entire `UserComment` byte array with `Encoding.ASCII`, including the 8-byte EXIF encoding identifier that prefixes the value. This caused three problems:

- The encoding header bytes were decoded as garbage and included in the output.
- Comments with an `ASCII` prefix were discarded (`string.Empty` returned).
- Comments with a `UNICODE` prefix were never re-decoded as UTF-16LE — only a string `Replace("UNICODE", "")` was performed on the already-ASCII-decoded text, so CJK and other non-ASCII comments stayed garbled.

## Fix

Read the first 8 bytes as the encoding identifier and decode only the remaining bytes (`commentBytes[8..]`) with the encoding indicated by the header, per the EXIF UserComment specification:

- `ASCII` → `Encoding.ASCII`
- `UNICODE` → `Encoding.Unicode` (UTF-16LE)
- `JIS` → UTF-8 fallback (true JIS X0208 decoding is rare in the wild; UTF-8 is a safe best-effort)
- undefined / all-NUL header → `Encoding.UTF8`

Trailing NUL padding and whitespace are trimmed from the decoded result, which is returned as `string.Empty` when null/empty/whitespace.

## Notes

- No public API change; single method replaced.
- Preserves the existing null/length guard and try/catch defensive style.
- Uses only `System.Text` encodings already imported (`Encoding.ASCII`, `Encoding.Unicode`, `Encoding.UTF8`).