### PR TITLE
Fix mouse side-button double-click triggering left-button behavior

### DIFF
--- a/src/PicView.Avalonia/Input/MouseShortcuts.cs
+++ b/src/PicView.Avalonia/Input/MouseShortcuts.cs
@@ -241,8 +241,10 @@ public static class MouseShortcuts
                     return;
             }
         }
-        // Handle double click
-        if (e.ClickCount is 2)
+        // Handle double click (only for the left mouse button, so that rapid
+        // double-clicks of the side buttons don't fall through and trigger the
+        // left-button double-click behavior such as toggling fullscreen)
+        if (e.ClickCount is 2 && prop.IsLeftButtonPressed)
         {
             switch (Settings.UIProperties.DoubleClickBehavior)
             {


### PR DESCRIPTION
Fixes #327

## Root cause

When mouse side buttons (XButton1/XButton2) are configured for file-history navigation, rapidly double-clicking them could trigger the left-button double-click behavior (e.g. toggling fullscreen) instead of just navigating.

In `MainWindow_PointerPressed` the XButton1/XButton2 branches return early after handling navigation. However, on a double-click the second `PointerPressed` event can report the side button as no longer pressed — `e.GetCurrentPoint(...).Properties` reflects the current pointer state, not which button initiated the press — so control fell through to the `e.ClickCount is 2` block, which applied the left-button `DoubleClickBehavior` (reset zoom / toggle fullscreen) regardless of which button was clicked.

## Fix

Guard the double-click block with `prop.IsLeftButtonPressed` so it only runs for the left mouse button:

```csharp
if (e.ClickCount is 2 && prop.IsLeftButtonPressed)
```

This matches the guard already used in `WindowFunctions.WindowDragAndDoubleClickBehavior` (`e.ClickCount == 2 && ... IsLeftButtonPressed`), so the behavior is now consistent across the codebase.

## Notes

- No public API change; single condition addition.
- The XButton1/XButton2 navigation branches are unchanged.
- Reproduces the user-reported scenario in #327 (side buttons set to navigate file history, double-click set to fullscreen).