### PR TITLE
Fix truncated titlebar menu for long-word languages

### DIFF
--- a/src/PicView.Avalonia.Win32/Views/WinTitleBar.axaml.cs
+++ b/src/PicView.Avalonia.Win32/Views/WinTitleBar.axaml.cs
@@ -109,9 +109,14 @@ public partial class WinTitleBar : MainTitleBar
         vm.TopTitlebarViewModel.IsBtnPanelVisible.Value = false;
         LogoBorder.IsVisible = false;
         CreateTabButton.IsVisible = false;
-        
-        const int menuItemsCount = 6;
-        vm.TopTitlebarViewModel.MaxItemWidth.Value = Bounds.Width / menuItemsCount;
+
+        // Let each menu item size to its own text content instead of capping
+        // every item at (window width / count). A fixed per-item cap truncates
+        // longer translated strings (e.g. German "Einstellungen", Italian
+        // "Impostazioni") even when space is available, and the count below was
+        // wrong (6) for the 7 top-level items. The logo, button panel and tab
+        // button are already hidden above to free the full titlebar width.
+        vm.TopTitlebarViewModel.MaxItemWidth.Value = double.NaN;
         
         var truncatedPadding = new Thickness(2,0,2,0);
         FileMenuItem.Padding = truncatedPadding;


### PR DESCRIPTION
Fixes #323

## Root cause

The titlebar hamburger menu truncated menu item text for languages with longer words (e.g. German "Einstellungen", Italian "Impostazioni"), while English ("Settings") fit fine.

In `OpenTruncatedMenu` (WinTitleBar.axaml.cs), every menu item was capped at `Bounds.Width / menuItemsCount` via `MaxItemWidth`, and `menuItemsCount` was hardcoded to `6` even though there are **7** top-level items (File, Edit, View, Image, Navigate, Settings, Help). A fixed per-item cap truncates longer translated strings even when space is available.

## Fix

Set `MaxItemWidth` to `double.NaN` so each menu item sizes to its own text content instead of being capped at a fixed fraction of the window width. This matches the Linux titlebar (`LinuxTitlebar.axaml`), which has no `MaxWidth` binding and has no truncation reports.

`OpenTruncatedMenu` already hides the logo, button panel (`IsBtnPanelVisible = false`), and tab button to free the full titlebar width, so items have room to size to content on narrow windows.

## Notes

- No public API change; single method (`OpenTruncatedMenu`).
- Short-word languages (English) are unaffected — items still size to their (smaller) content.
- The unused `menuItemsCount` constant is removed.
- Cross-reference: the Linux titlebar already behaves this way.