### PR TITLE
Fix Ctrl+S triggering image rotation instead of save

### DIFF
--- a/src/PicView.Avalonia/Input/MainKeyboardShortcuts.cs
+++ b/src/PicView.Avalonia/Input/MainKeyboardShortcuts.cs
@@ -62,7 +62,13 @@ public static class MainKeyboardShortcuts
 #endif
 
         // Create key gesture from current state
-        CurrentKeys = new KeyGesture(e.Key, CurrentModifiers);
+        // Use e.KeyModifiers (from the event args) instead of the manually tracked
+        // CurrentModifiers, because the manual tracking can be out of sync if a
+        // modifier key-down event was missed (e.g. focus changes, window deactivation,
+        // or the modifier was pressed before the window had focus). This ensures that
+        // a bare-key binding such as "S" (rotate) only fires when no modifiers are
+        // actually held, so "Ctrl+S" (save) is never mistakenly dispatched as "S".
+        CurrentKeys = new KeyGesture(e.Key, e.KeyModifiers);
 
         // Track key repeat for held down state
         _keyRepeatCount++;


### PR DESCRIPTION
Fixes #342

## Root cause

When pressing `Ctrl+S` to save, the image would also rotate because the bare `S` keybinding (mapped to `Down` -> `RotateLeft`) was matched instead of `Ctrl+S` (`Save`).

`MainKeyboardShortcuts.MainWindow_KeysDownAsync` builds the `KeyGesture` for keybinding lookup from a manually tracked `CurrentModifiers` field:

```csharp
CurrentKeys = new KeyGesture(e.Key, CurrentModifiers);
```

`CurrentModifiers` is updated via `UpdateModifierState()` on each key-down/up, but it can be out of sync with the actual OS modifier state when a modifier key-down was missed — e.g. the modifier was pressed before the window had focus, or the window was deactivated (the `Deactivated` handler resets `CurrentModifiers` to `None`) and re-activated while the modifier was still held. When stale, the `S` gesture resolves to `KeyModifiers.None` and matches the bare rotate binding.

## Fix

Use `e.KeyModifiers` (from `KeyEventArgs`, which always reflects the true modifier state at event time) for `KeyGesture` creation:

```csharp
CurrentKeys = new KeyGesture(e.Key, e.KeyModifiers);
```

This matches the existing pattern in `InputHelper.cs` (`e.KeyModifiers == KeyModifiers.Control`) and Avalonia's own `KeyGesture.Matches(KeyEventArgs)`. `CurrentModifiers` is retained for its other uses (`ShiftDown`, `KeyUp` handler); only the gesture creation changes.

No public API change; single line.