### PR TITLE
Fix animation for GIFs with truncated extension tails

### DIFF
--- a/src/PicView.Avalonia/AnimatedImage/Decoding/GifDecoder.cs
+++ b/src/PicView.Avalonia/AnimatedImage/Decoding/GifDecoder.cs
@@ -555,6 +555,15 @@ public sealed class GifDecoder : IDisposable
                     break;
 
                 case BlockTypes.Extension:
+                    // Some otherwise valid GIFs end with a dangling extension introducer
+                    // instead of a trailer. Preserve the complete frames already parsed.
+                    if (_fileStream.Position >= _fileStream.Length)
+                    {
+                        Frames.RemoveAt(Frames.Count - 1);
+                        terminate = true;
+                        break;
+                    }
+
                     ProcessExtensions(ref curFrame, tempBuf);
                     break;
 

--- a/src/PicView.Avalonia/ImageHandling/GetImageModel.cs
+++ b/src/PicView.Avalonia/ImageHandling/GetImageModel.cs
@@ -1,6 +1,7 @@
 using Avalonia.Media.Imaging;
 using Avalonia.Svg.Skia;
 using ImageMagick;
+using PicView.Avalonia.AnimatedImage.Decoding;
 using PicView.Avalonia.Svg;
 using PicView.Core.DebugTools;
 using PicView.Core.Exif;
@@ -84,7 +85,7 @@ public static class GetImageModel
                         await ProcessSkBitmapAsync(fileInfo, magickImage.Format, imageModel).ConfigureAwait(false);
                     }
 
-                    if (ImageAnalyzer.IsAnimated(fileInfo))
+                    if (IsAnimatedGif(fileInfo))
                     {
                         imageModel.ImageType = ImageType.AnimatedGif;
                     }
@@ -190,6 +191,39 @@ public static class GetImageModel
         }
 
         return colorProfile.Description?.Contains("sRGB", StringComparison.OrdinalIgnoreCase) != true;
+    }
+
+    internal static bool IsAnimatedGif(FileInfo fileInfo)
+    {
+        if (ImageAnalyzer.IsAnimated(fileInfo))
+        {
+            return true;
+        }
+
+        try
+        {
+            using var stream = fileInfo.OpenRead();
+
+            if (stream.Length == 0)
+            {
+                return false;
+            }
+
+            stream.Position = stream.Length - 1;
+            if (stream.ReadByte() != (byte)BlockTypes.Extension)
+            {
+                return false;
+            }
+
+            stream.Position = 0;
+            using var decoder = new GifDecoder(stream, CancellationToken.None);
+            return decoder.Frames.Count > 1;
+        }
+        catch (Exception e)
+        {
+            DebugHelper.LogDebug(nameof(GetImageModel), nameof(IsAnimatedGif), e);
+            return false;
+        }
     }
 
     #region Image Processing Methods

--- a/src/PicView.Tests/AnimatedImage/GifDecoderTests.cs
+++ b/src/PicView.Tests/AnimatedImage/GifDecoderTests.cs
@@ -1,0 +1,37 @@
+using PicView.Avalonia.AnimatedImage.Decoding;
+using PicView.Avalonia.ImageHandling;
+
+namespace PicView.Tests.AnimatedImage;
+
+public class GifDecoderTests
+{
+    [Fact]
+    public void Constructor_DanglingExtensionIntroducer_PreservesCompleteFrames()
+    {
+        using var stream = new MemoryStream(GetGifWithDanglingExtension());
+
+        using var decoder = new GifDecoder(stream, CancellationToken.None);
+
+        Assert.Equal(2, decoder.Frames.Count);
+    }
+
+    [Fact]
+    public void IsAnimatedGif_DanglingExtensionIntroducer_ReturnsTrue()
+    {
+        var filePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.gif");
+
+        try
+        {
+            File.WriteAllBytes(filePath, GetGifWithDanglingExtension());
+
+            Assert.True(GetImageModel.IsAnimatedGif(new FileInfo(filePath)));
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    private static byte[] GetGifWithDanglingExtension() => Convert.FromBase64String(
+        "R0lGODlhAgABAIEAAAAAAAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQABwAAACwAAAAAAgABAAAIBQABAAgIACH5BAEHAAEALAAAAAACAAEAgf///wAAAAAAAAAAAAgFAAEACAgAIQ==");
+}


### PR DESCRIPTION
## Description

- Preserve complete GIF frames when an otherwise valid file ends with a dangling extension introducer (`0x21`) instead of a trailer.
- Keep ImageMagick as the normal animation-detection fast path and invoke the tolerant decoder only when that detection fails and the file has the specific malformed ending.
- Add direct decoder and integration regression tests for the malformed tail.

## Motivation and Context

The GIF attached to issue #217 contains 34 complete frames but ends with a lone extension introducer. ImageMagick therefore reports it as non-animated, and PicView displays only a static frame. The fallback recognizes that narrow malformed-tail case without modifying the source file or adding decoding overhead to ordinary GIF detection.

Fixes #217

## How Has This Been Tested?

- Focused `GifDecoderTests`: 2 passed, 0 failed.
- Windows x64 Debug build succeeded with .NET SDK `11.0.100-preview.6.26359.118`.
- Tested the exact GIF from issue #217 in the rebuilt Windows application; captures taken 700 ms apart showed different animation frames.
- `git diff --check` passed.

The complete test project currently has unrelated pre-existing compilation failures, so the two regression tests were built and run in isolation.

## Screenshots (if appropriate):

Not included; the issue GIF itself was used for the manual before/after verification.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
