### PR TITLE
Fix top-right corner close targets

### DIFF
--- a/src/PicView.Avalonia.Win32/Views/AboutWindow.axaml
+++ b/src/PicView.Avalonia.Win32/Views/AboutWindow.axaml
@@ -19,7 +19,10 @@
         x:Name="ParentBorder">
         <StackPanel>
 
-            <DockPanel Height="28" LastChildFill="True">
+            <DockPanel
+                Height="28"
+                Margin="0,-1,-1,0"
+                LastChildFill="True">
 
                 <Border
                     Background="{DynamicResource WindowButtonBackgroundColor}"
@@ -47,6 +50,7 @@
                     IconWidth="10"
                     IsRepeatEnabled="False"
                     Width="30"
+                    WindowDecorationProperties.ElementRole="CloseButton"
                     x:Name="CloseButton" />
 
                 <customControls:IconButton

--- a/src/PicView.Avalonia.Win32/Views/AboutWindow.axaml.cs
+++ b/src/PicView.Avalonia.Win32/Views/AboutWindow.axaml.cs
@@ -6,7 +6,7 @@ using PicView.Core.Update;
 
 namespace PicView.Avalonia.Win32.Views;
 
-public partial class AboutWindow : GenericWindow, IPlatformSpecificUpdate
+public partial class AboutWindow : Win32GenericWindow, IPlatformSpecificUpdate
 {
     public AboutWindow()
     {

--- a/src/PicView.Avalonia.Win32/Views/BatchResizeResizeWindow.axaml
+++ b/src/PicView.Avalonia.Win32/Views/BatchResizeResizeWindow.axaml
@@ -17,6 +17,7 @@
 
             <DockPanel
                 Height="{StaticResource TopBorderHeight}"
+                Margin="0,-1,-1,0"
                 DockPanel.Dock="Top"
                 LastChildFill="True">
 
@@ -46,7 +47,8 @@
                     Foreground="{DynamicResource MainTextColor}"
                     IconHeight="10"
                     IconWidth="10"
-                    IsRepeatEnabled="False" />
+                    IsRepeatEnabled="False"
+                    WindowDecorationProperties.ElementRole="CloseButton" />
 
                 <customControls:IconButton
                     x:Name="MinimizeButton"

--- a/src/PicView.Avalonia.Win32/Views/BatchResizeResizeWindow.axaml.cs
+++ b/src/PicView.Avalonia.Win32/Views/BatchResizeResizeWindow.axaml.cs
@@ -12,7 +12,7 @@ using R3;
 
 namespace PicView.Avalonia.Win32.Views;
 
-public partial class BatchResizeWindow : GenericWindow, IDisposable
+public partial class BatchResizeWindow : Win32GenericWindow, IDisposable
 {
     private DisposableBag _disposables;
     public BatchResizeWindow(BatchResizeWindowConfig config)

--- a/src/PicView.Avalonia.Win32/Views/ConvertWindow.axaml
+++ b/src/PicView.Avalonia.Win32/Views/ConvertWindow.axaml
@@ -17,6 +17,7 @@
 
             <DockPanel
                 Height="28"
+                Margin="0,-1,-1,0"
                 Background="Transparent"
                 LastChildFill="True"
                 PointerPressed="MoveWindow">
@@ -47,7 +48,8 @@
                     Foreground="{DynamicResource MainTextColor}"
                     IconHeight="10"
                     IconWidth="10"
-                    IsRepeatEnabled="False" />
+                    IsRepeatEnabled="False"
+                    WindowDecorationProperties.ElementRole="CloseButton" />
 
                 <customControls:IconButton
                     x:Name="MinimizeButton"

--- a/src/PicView.Avalonia.Win32/Views/ConvertWindow.axaml.cs
+++ b/src/PicView.Avalonia.Win32/Views/ConvertWindow.axaml.cs
@@ -8,7 +8,7 @@ using PicView.Core.Localization;
 
 namespace PicView.Avalonia.Win32.Views;
 
-public partial class ConvertWindow : GenericWindow
+public partial class ConvertWindow : Win32GenericWindow
 {
     public ConvertWindow()
     {

--- a/src/PicView.Avalonia.Win32/Views/EffectsWindow.axaml
+++ b/src/PicView.Avalonia.Win32/Views/EffectsWindow.axaml
@@ -19,6 +19,7 @@
             <DockPanel
                 Background="{DynamicResource WindowSecondaryBackgroundColor}"
                 Height="28"
+                Margin="0,-1,-1,0"
                 LastChildFill="True"
                 PointerPressed="MoveWindow"
                 x:Name="TitleBarPanel">
@@ -49,6 +50,7 @@
                     IconWidth="10"
                     IsRepeatEnabled="False"
                     Width="30"
+                    WindowDecorationProperties.ElementRole="CloseButton"
                     x:Name="CloseButton" />
 
                 <customControls:IconButton

--- a/src/PicView.Avalonia.Win32/Views/EffectsWindow.axaml.cs
+++ b/src/PicView.Avalonia.Win32/Views/EffectsWindow.axaml.cs
@@ -8,7 +8,7 @@ using R3;
 
 namespace PicView.Avalonia.Win32.Views;
 
-public partial class EffectsWindow : GenericWindow, IDisposable
+public partial class EffectsWindow : Win32GenericWindow, IDisposable
 {
     private readonly CompositeDisposable _disposables = new();
     public EffectsWindow(EffectsWindowConfig config)

--- a/src/PicView.Avalonia.Win32/Views/FileAssociationWindow.axaml
+++ b/src/PicView.Avalonia.Win32/Views/FileAssociationWindow.axaml
@@ -20,6 +20,7 @@
 
             <DockPanel
                 Height="28"
+                Margin="0,-1,-1,0"
                 LastChildFill="True"
                 PointerPressed="MoveWindow">
 
@@ -49,7 +50,8 @@
                     Foreground="{DynamicResource MainTextColor}"
                     IconHeight="10"
                     IconWidth="10"
-                    IsRepeatEnabled="False" />
+                    IsRepeatEnabled="False"
+                    WindowDecorationProperties.ElementRole="CloseButton" />
 
                 <customControls:IconButton
                     x:Name="MinimizeButton"

--- a/src/PicView.Avalonia.Win32/Views/FileAssociationWindow.axaml.cs
+++ b/src/PicView.Avalonia.Win32/Views/FileAssociationWindow.axaml.cs
@@ -11,7 +11,7 @@ using R3;
 
 namespace PicView.Avalonia.Win32.Views;
 
-public partial class FileAssociationWindow : GenericWindow
+public partial class FileAssociationWindow : Win32GenericWindow
 {
     private readonly List<(CheckBox CheckBox, string SearchText)> _allCheckBoxes = [];
     private readonly CompositeDisposable _disposables = new();

--- a/src/PicView.Avalonia.Win32/Views/ImageInfoWindow.axaml
+++ b/src/PicView.Avalonia.Win32/Views/ImageInfoWindow.axaml
@@ -26,6 +26,7 @@
             <DockPanel
                 x:Name="TopWindowBorder"
                 Height="28"
+                Margin="0,-1,-1,0"
                 Background="{DynamicResource WindowBackgroundColor}"
                 DockPanel.Dock="Top"
                 LastChildFill="True">
@@ -50,7 +51,8 @@
                     Foreground="{DynamicResource MainTextColor}"
                     IconHeight="10"
                     IconWidth="10"
-                    IsRepeatEnabled="False" />
+                    IsRepeatEnabled="False"
+                    WindowDecorationProperties.ElementRole="CloseButton" />
 
                 <customControls:IconButton
                     x:Name="MinimizeButton"

--- a/src/PicView.Avalonia.Win32/Views/ImageInfoWindow.axaml.cs
+++ b/src/PicView.Avalonia.Win32/Views/ImageInfoWindow.axaml.cs
@@ -10,7 +10,7 @@ using R3;
 
 namespace PicView.Avalonia.Win32.Views;
 
-public partial class ImageInfoWindow: GenericWindow, IDisposable
+public partial class ImageInfoWindow: Win32GenericWindow, IDisposable
 {
     private readonly CompositeDisposable _disposables = new();
 

--- a/src/PicView.Avalonia.Win32/Views/KeybindingsWindow.axaml
+++ b/src/PicView.Avalonia.Win32/Views/KeybindingsWindow.axaml
@@ -20,6 +20,7 @@
 
             <DockPanel
                 Height="28"
+                Margin="0,-1,-1,0"
                 VerticalAlignment="Top"
                 LastChildFill="True">
 
@@ -50,7 +51,8 @@
                     IconWidth="10"
                     IsRepeatEnabled="False"
                     ToolTip.Tip="{CompiledBinding Translation.Close.Value,
-                                                  Mode=OneWay}" />
+                                                  Mode=OneWay}"
+                    WindowDecorationProperties.ElementRole="CloseButton" />
 
                 <customControls:IconButton
                     x:Name="MinimizeButton"

--- a/src/PicView.Avalonia.Win32/Views/KeybindingsWindow.axaml.cs
+++ b/src/PicView.Avalonia.Win32/Views/KeybindingsWindow.axaml.cs
@@ -7,7 +7,7 @@ using PicView.Core.Localization;
 
 namespace PicView.Avalonia.Win32.Views;
 
-public partial class KeybindingsWindow : GenericWindow
+public partial class KeybindingsWindow : Win32GenericWindow
 {
     public KeybindingsWindow(KeybindingWindowConfig config)
     {

--- a/src/PicView.Avalonia.Win32/Views/PrintPreviewWindow.axaml
+++ b/src/PicView.Avalonia.Win32/Views/PrintPreviewWindow.axaml
@@ -19,6 +19,7 @@
 
             <DockPanel
                 Height="28"
+                Margin="0,-1,-1,0"
                 DockPanel.Dock="Top"
                 LastChildFill="True"
                 PointerPressed="MoveWindow">
@@ -49,7 +50,8 @@
                     Foreground="{DynamicResource MainTextColor}"
                     IconHeight="10"
                     IconWidth="10"
-                    IsRepeatEnabled="False" />
+                    IsRepeatEnabled="False"
+                    WindowDecorationProperties.ElementRole="CloseButton" />
 
                 <customControls:IconButton
                     x:Name="MinimizeButton"

--- a/src/PicView.Avalonia.Win32/Views/PrintPreviewWindow.axaml.cs
+++ b/src/PicView.Avalonia.Win32/Views/PrintPreviewWindow.axaml.cs
@@ -8,7 +8,7 @@ using PicView.Core.Localization;
 
 namespace PicView.Avalonia.Win32.Views;
 
-public partial class PrintPreviewWindow : PrintWindow
+public partial class PrintPreviewWindow : Win32PrintWindow
 {
     public PrintPreviewWindow(PrintWindowConfig config)
     {

--- a/src/PicView.Avalonia.Win32/Views/SettingsWindow.axaml
+++ b/src/PicView.Avalonia.Win32/Views/SettingsWindow.axaml
@@ -25,7 +25,10 @@
                 BorderBrush="{DynamicResource MainBorderColor}"
                 BorderThickness="0,0,0,1"
                 DockPanel.Dock="Top">
-                <DockPanel VerticalAlignment="Top" LastChildFill="True">
+                <DockPanel
+                    Margin="0,-1,-1,0"
+                    VerticalAlignment="Top"
+                    LastChildFill="True">
                     <Border
                         x:Name="LogoBorder"
                         Background="{DynamicResource WindowSecondaryBackgroundColor}"
@@ -96,7 +99,8 @@
                         IconWidth="10"
                         IsRepeatEnabled="False"
                         ToolTip.Tip="{CompiledBinding Translation.Close.Value,
-                                                      Mode=OneWay}" />
+                                                      Mode=OneWay}"
+                        WindowDecorationProperties.ElementRole="CloseButton" />
 
                     <customControls:IconButton
                         x:Name="MinimizeButton"

--- a/src/PicView.Avalonia.Win32/Views/SettingsWindow.axaml.cs
+++ b/src/PicView.Avalonia.Win32/Views/SettingsWindow.axaml.cs
@@ -16,7 +16,7 @@ using R3;
 
 namespace PicView.Avalonia.Win32.Views;
 
-public partial class SettingsWindow : GenericWindow
+public partial class SettingsWindow : Win32GenericWindow
 {
     
     public SettingsWindow(SettingsWindowConfig config)

--- a/src/PicView.Avalonia.Win32/Views/SingleImageResizeWindow.axaml
+++ b/src/PicView.Avalonia.Win32/Views/SingleImageResizeWindow.axaml
@@ -20,6 +20,7 @@
 
             <DockPanel
                 Height="{StaticResource TopBorderHeight}"
+                Margin="0,-1,-1,0"
                 LastChildFill="True"
                 PointerPressed="MoveWindow">
 
@@ -49,6 +50,7 @@
                     IconWidth="10"
                     IsRepeatEnabled="False"
                     Width="30"
+                    WindowDecorationProperties.ElementRole="CloseButton"
                     x:Name="CloseButton" />
 
                 <customControls:IconButton

--- a/src/PicView.Avalonia.Win32/Views/SingleImageResizeWindow.axaml.cs
+++ b/src/PicView.Avalonia.Win32/Views/SingleImageResizeWindow.axaml.cs
@@ -9,7 +9,7 @@ using PicView.Core.ViewModels;
 
 namespace PicView.Avalonia.Win32.Views;
 
-public partial class SingleImageResizeWindow : GenericWindow
+public partial class SingleImageResizeWindow : Win32GenericWindow
 {
     public SingleImageResizeWindow(MainWindowViewModel viewModel)
     {

--- a/src/PicView.Avalonia.Win32/Views/Win32GenericWindow.cs
+++ b/src/PicView.Avalonia.Win32/Views/Win32GenericWindow.cs
@@ -1,0 +1,14 @@
+using PicView.Avalonia.CustomControls;
+using PicView.Avalonia.Win32.WindowImpl;
+
+namespace PicView.Avalonia.Win32.Views;
+
+public class Win32GenericWindow : GenericWindow
+{
+    protected Win32GenericWindow() => CaptionButtonCornerHandler.Attach(this);
+}
+
+public class Win32PrintWindow : PrintWindow
+{
+    protected Win32PrintWindow() => CaptionButtonCornerHandler.Attach(this);
+}

--- a/src/PicView.Avalonia.Win32/Views/WinMainWindow.axaml.cs
+++ b/src/PicView.Avalonia.Win32/Views/WinMainWindow.axaml.cs
@@ -29,6 +29,7 @@ public partial class WinMainWindow : MainWindow, IPlatformWindowService
         DataContext = mainWindowViewModel;
 
         InitializeComponent();
+        CaptionButtonCornerHandler.Attach(this, () => IsCloseButtonEffectivelyVisible(mainWindowViewModel));
         
         SharedBottomBar = BottomBar;
         SharedTitleBar = Titlebar;
@@ -36,6 +37,10 @@ public partial class WinMainWindow : MainWindow, IPlatformWindowService
         UIHelper.Initialize(this);
         LoadedInitialization();
     }
+
+    private bool IsCloseButtonEffectivelyVisible(MainWindowViewModel vm) =>
+        (Titlebar.IsEffectivelyVisible && vm.TopTitlebarViewModel.IsBtnPanelVisible.CurrentValue) ||
+        MainView.IsAlternativeCloseButtonEffectivelyVisible;
 
     private void LoadedInitialization()
     {

--- a/src/PicView.Avalonia.Win32/Views/WinTitleBar.axaml
+++ b/src/PicView.Avalonia.Win32/Views/WinTitleBar.axaml
@@ -1012,6 +1012,7 @@
                 x:Name="WinBtnPanel"
                 DockPanel.Dock="Right"
                 IsVisible="{CompiledBinding TopTitlebarViewModel.IsBtnPanelVisible.Value}"
+                Margin="0,-1,-1,0"
                 Orientation="Horizontal">
 
                 <customControls:IconButton
@@ -1074,7 +1075,8 @@
                     Foreground="{DynamicResource MainTextColor}"
                     IconHeight="10"
                     IconWidth="10"
-                    IsRepeatEnabled="False" />
+                    IsRepeatEnabled="False"
+                    WindowDecorationProperties.ElementRole="CloseButton" />
 
             </StackPanel>
 

--- a/src/PicView.Avalonia.Win32/WindowImpl/CaptionButtonCornerHandler.cs
+++ b/src/PicView.Avalonia.Win32/WindowImpl/CaptionButtonCornerHandler.cs
@@ -1,0 +1,188 @@
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.Win32.Interop;
+
+namespace PicView.Avalonia.Win32.WindowImpl;
+
+internal sealed class CaptionButtonCornerHandler
+{
+    private const double CaptionButtonSize = 30;
+    private const uint WmCancelMode = 0x001F;
+    private const uint WmNcHitTest = 0x0084;
+    private const uint WmNcLeftButtonDown = 0x00A1;
+    private const uint WmNcLeftButtonUp = 0x00A2;
+    private const uint WmLeftButtonUp = 0x0202;
+    private const uint WmCaptureChanged = 0x0215;
+    private static readonly IntPtr HtClose = new(20);
+
+    private readonly Window _window;
+    private readonly Func<bool> _isEnabled;
+    private bool _isCloseButtonPressed;
+
+    public CaptionButtonCornerHandler(Window window, Func<bool> isEnabled)
+    {
+        _window = window;
+        _isEnabled = isEnabled;
+        _window.Opened += OnOpened;
+        _window.Closed += OnClosed;
+    }
+
+    internal static void Attach(Window window, Func<bool>? isEnabled = null) =>
+        _ = new CaptionButtonCornerHandler(window, isEnabled ?? (() => true));
+
+    private void OnOpened(object? sender, EventArgs e) =>
+        Win32Properties.AddWndProcHookCallback(_window, WndProc);
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        Win32Properties.RemoveWndProcHookCallback(_window, WndProc);
+        _window.Opened -= OnOpened;
+        _window.Closed -= OnClosed;
+    }
+
+    private IntPtr WndProc(IntPtr hWnd, uint message, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        if (message == WmCaptureChanged)
+        {
+            _isCloseButtonPressed = false;
+            return IntPtr.Zero;
+        }
+
+        if (message == WmCancelMode)
+        {
+            CancelPress(hWnd);
+            return IntPtr.Zero;
+        }
+
+        if (message == WmNcLeftButtonDown && wParam == HtClose && _isEnabled())
+        {
+            _isCloseButtonPressed = true;
+            SetCapture(hWnd);
+            _isCloseButtonPressed = GetCapture() == hWnd;
+            handled = true;
+            return IntPtr.Zero;
+        }
+
+        if ((message is WmLeftButtonUp or WmNcLeftButtonUp) && _isCloseButtonPressed)
+        {
+            var shouldClose = _isEnabled() && IsCursorInCloseButtonArea(hWnd);
+            CancelPress(hWnd);
+            handled = true;
+
+            if (shouldClose)
+            {
+                Dispatcher.UIThread.Post(_window.Close);
+            }
+
+            return IntPtr.Zero;
+        }
+
+        if (message != WmNcHitTest || !_isEnabled() || !IsInCloseButtonArea(hWnd, lParam))
+        {
+            return IntPtr.Zero;
+        }
+
+        handled = true;
+        return HtClose;
+    }
+
+    private void CancelPress(IntPtr hWnd)
+    {
+        _isCloseButtonPressed = false;
+        if (GetCapture() == hWnd)
+        {
+            ReleaseCapture();
+        }
+    }
+
+    private bool IsCursorInCloseButtonArea(IntPtr hWnd) =>
+        GetCursorPos(out var pointerPosition) &&
+        IsInCloseButtonArea(hWnd, pointerPosition.X, pointerPosition.Y);
+
+    private bool IsInCloseButtonArea(IntPtr hWnd, IntPtr lParam)
+    {
+        var packedPosition = lParam.ToInt64();
+        var pointerX = (short)(packedPosition & 0xffff);
+        var pointerY = (short)((packedPosition >> 16) & 0xffff);
+
+        return IsInCloseButtonArea(hWnd, pointerX, pointerY);
+    }
+
+    private bool IsInCloseButtonArea(IntPtr hWnd, int pointerX, int pointerY)
+    {
+        if (!TryGetWindowArea(hWnd, out var windowArea))
+        {
+            return false;
+        }
+
+        var closeButtonSize = (int)Math.Ceiling(CaptionButtonSize * _window.RenderScaling);
+
+        return pointerX >= windowArea.Right - closeButtonSize && pointerX < windowArea.Right &&
+               pointerY >= windowArea.Y && pointerY < windowArea.Y + closeButtonSize;
+    }
+
+    private bool TryGetWindowArea(IntPtr hWnd, out PixelRect windowArea)
+    {
+        var screen = _window.Screens.ScreenFromWindow(_window);
+        if (_window.WindowState == WindowState.FullScreen && screen is not null)
+        {
+            windowArea = screen.Bounds;
+            return true;
+        }
+
+        if (_window.WindowState == WindowState.Maximized && screen is not null)
+        {
+            windowArea = screen.WorkingArea;
+            return true;
+        }
+
+        if (GetWindowRect(hWnd, out var windowRect))
+        {
+            windowArea = new PixelRect(
+                windowRect.Left,
+                windowRect.Top,
+                windowRect.Right - windowRect.Left,
+                windowRect.Bottom - windowRect.Top);
+            return true;
+        }
+
+        windowArea = default;
+        return false;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetWindowRect(IntPtr hWnd, out WindowRect windowRect);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr SetCapture(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool ReleaseCapture();
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetCapture();
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetCursorPos(out ScreenPoint pointerPosition);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private record struct ScreenPoint
+    {
+        public int X;
+        public int Y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private record struct WindowRect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+}

--- a/src/PicView.Avalonia.Win32/WindowImpl/CaptionButtonCornerHandler.cs
+++ b/src/PicView.Avalonia.Win32/WindowImpl/CaptionButtonCornerHandler.cs
@@ -1,8 +1,8 @@
-using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
 using Avalonia.Win32.Interop;
+using PicView.Core.WindowsNT;
 
 namespace PicView.Avalonia.Win32.WindowImpl;
 
@@ -59,8 +59,8 @@ internal sealed class CaptionButtonCornerHandler
         if (message == WmNcLeftButtonDown && wParam == HtClose && _isEnabled())
         {
             _isCloseButtonPressed = true;
-            SetCapture(hWnd);
-            _isCloseButtonPressed = GetCapture() == hWnd;
+            NativeMethods.SetCapture(hWnd);
+            _isCloseButtonPressed = NativeMethods.GetCapture() == hWnd;
             handled = true;
             return IntPtr.Zero;
         }
@@ -91,14 +91,14 @@ internal sealed class CaptionButtonCornerHandler
     private void CancelPress(IntPtr hWnd)
     {
         _isCloseButtonPressed = false;
-        if (GetCapture() == hWnd)
+        if (NativeMethods.GetCapture() == hWnd)
         {
-            ReleaseCapture();
+            NativeMethods.ReleaseCapture();
         }
     }
 
     private bool IsCursorInCloseButtonArea(IntPtr hWnd) =>
-        GetCursorPos(out var pointerPosition) &&
+        NativeMethods.GetCursorPos(out var pointerPosition) &&
         IsInCloseButtonArea(hWnd, pointerPosition.X, pointerPosition.Y);
 
     private bool IsInCloseButtonArea(IntPtr hWnd, IntPtr lParam)
@@ -138,7 +138,7 @@ internal sealed class CaptionButtonCornerHandler
             return true;
         }
 
-        if (GetWindowRect(hWnd, out var windowRect))
+        if (NativeMethods.GetWindowRect(hWnd, out var windowRect))
         {
             windowArea = new PixelRect(
                 windowRect.Left,
@@ -150,39 +150,5 @@ internal sealed class CaptionButtonCornerHandler
 
         windowArea = default;
         return false;
-    }
-
-    [DllImport("user32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool GetWindowRect(IntPtr hWnd, out WindowRect windowRect);
-
-    [DllImport("user32.dll")]
-    private static extern IntPtr SetCapture(IntPtr hWnd);
-
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool ReleaseCapture();
-
-    [DllImport("user32.dll")]
-    private static extern IntPtr GetCapture();
-
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool GetCursorPos(out ScreenPoint pointerPosition);
-
-    [StructLayout(LayoutKind.Sequential)]
-    private record struct ScreenPoint
-    {
-        public int X;
-        public int Y;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private record struct WindowRect
-    {
-        public int Left;
-        public int Top;
-        public int Right;
-        public int Bottom;
     }
 }

--- a/src/PicView.Avalonia/Views/Main/MainView.axaml.cs
+++ b/src/PicView.Avalonia/Views/Main/MainView.axaml.cs
@@ -19,6 +19,8 @@ namespace PicView.Avalonia.Views.Main;
 
 public partial class MainView : UserControl
 {
+    public bool IsAlternativeCloseButtonEffectivelyVisible => AltClose.IsEffectivelyVisible;
+
     public MainView()
     {
         InitializeComponent();

--- a/src/PicView.Core.WindowsNT/NativeMethods.cs
+++ b/src/PicView.Core.WindowsNT/NativeMethods.cs
@@ -20,6 +20,45 @@ public static partial class NativeMethods
     public static partial void SHChangeNotify(int wEventId, int uFlags, IntPtr dwItem1, IntPtr dwItem2);
     
     
+    #region Window management
+
+    [LibraryImport("user32.dll")]
+    public static partial IntPtr GetCapture();
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool GetCursorPos(out ScreenPoint pointerPosition);
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool GetWindowRect(IntPtr hWnd, out WindowRect windowRect);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool ReleaseCapture();
+
+    [LibraryImport("user32.dll")]
+    public static partial IntPtr SetCapture(IntPtr hWnd);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct ScreenPoint
+    {
+        public int X;
+        public int Y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct WindowRect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    #endregion Window management
+
+
     #region Disable Screensaver and Power options
 
     private const uint ES_CONTINUOUS = 0x80000000;


### PR DESCRIPTION
## Summary

- make the top-right corner a reliable close target for the Windows main window in normal, maximized, and fullscreen states
- apply the same behavior consistently to PicView's Windows dialog windows
- preserve Avalonia close-button hover semantics while handling the outermost corner with DPI-, monitor-, and taskbar-aware Win32 hit testing
- cancel a pending close when the pointer is dragged away, and avoid closing when a drag only ends in the corner

## Root cause

PicView uses custom Avalonia window chrome, and the outermost top-right pixel was outside the effective close target in several window states and dialogs. The native system Close command is disabled for this custom chrome, so returning the standard close hit-test value alone did not activate the close action.

## Validation

- `dotnet build src/PicView.Avalonia.Win32/PicView.Avalonia.Win32.csproj -c Debug -p:Platform=x64` — succeeds with 0 errors
- manually verified exact-corner closing in normal, maximized, fullscreen, and Settings windows
- manually verified dragging from the corner outward does not close
- manually verified dragging from outside into the corner does not close
- `git diff --check upstream/dev...HEAD`

The repository's full test project is currently blocked by pre-existing stale test mocks and the .NET 11 VSTest/Microsoft Testing Platform mismatch; those files are not changed here.

Fixes #320
