### PR TITLE
FEAT: Add 'Always uncompress entire archive' option

### DIFF
--- a/src/PicView.Avalonia/DragAndDrop/DragAndDropManager.cs
+++ b/src/PicView.Avalonia/DragAndDrop/DragAndDropManager.cs
@@ -79,7 +79,16 @@ public static class DragAndDropManager
         {
             if (tabOverview.ActiveTab.CurrentValue.IsInitialized)
             {
-                await tabOverview.LoadFromArchiveAsync(path);
+                var vm = core.MainWindows.ActiveWindow.CurrentValue;
+                vm.IsLoadingIndicatorShown.Value = true;
+                try
+                {
+                    await tabOverview.LoadFromArchiveAsync(path);
+                }
+                finally
+                {
+                    vm.IsLoadingIndicatorShown.Value = false;
+                }
             }
             else
             {
@@ -231,7 +240,16 @@ public static class DragAndDropManager
                 tab.CurrentView.Value = new ImageViewer();
             }
 
-            await tabOverview.LoadFromFileAsync(file);
+            var vm = mainWindow.DataContext as MainWindowViewModel;
+            if (vm != null) vm.IsLoadingIndicatorShown.Value = true;
+            try
+            {
+                await tabOverview.LoadFromFileAsync(file);
+            }
+            finally
+            {
+                if (vm != null) vm.IsLoadingIndicatorShown.Value = false;
+            }
         }
         else
         {

--- a/src/PicView.Avalonia/FileSystem/FilePicker.cs
+++ b/src/PicView.Avalonia/FileSystem/FilePicker.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
@@ -46,7 +46,15 @@ public static class FilePicker
         });
 
 
-        await vm.WindowTabs.LoadFromFileAsync(file).ConfigureAwait(false);
+        vm.IsLoadingIndicatorShown.Value = true;
+        try
+        {
+            await vm.WindowTabs.LoadFromFileAsync(file).ConfigureAwait(false);
+        }
+        finally
+        {
+            vm.IsLoadingIndicatorShown.Value = false;
+        }
         vm.TopTitlebarViewModel.DropDownMenu.CloseMenus();
         vm.TopTitlebarViewModel.DropDownMenu.IsDropDownMenuVisible.Value = false;
     }

--- a/src/PicView.Avalonia/Views/Config/NavigationView.axaml
+++ b/src/PicView.Avalonia/Views/Config/NavigationView.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="PicView.Avalonia.Views.Config.NavigationView"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -53,6 +53,17 @@
                 IsChecked="{CompiledBinding SettingsViewModel.IsShowingTaskbarProgress.Value,
                                             Mode=OneWay}"
                 Text="{CompiledBinding Translation.ToggleTaskbarProgress.Value,
+                                       Mode=OneWay}" />
+        </Border>
+
+        <!--  Always uncompress entire archive folder  -->
+        <Border ui:SearchProperties.Keywords="{CompiledBinding SettingsViewModel.SearchData.NavigationArchiveSearchTags}" Classes="searchBorder">
+            <customControls:TextToggleButton
+                x:Name="AlwaysUncompressEntireArchiveToggleButton"
+                Classes="altHover settingsToggleButton"
+                IsChecked="{CompiledBinding SettingsViewModel.IsUncompressingEntireArchive.Value,
+                                            Mode=TwoWay}"
+                Text="{CompiledBinding Translation.AlwaysUncompressEntireArchive.Value,
                                        Mode=OneWay}" />
         </Border>
 

--- a/src/PicView.Benchmarks/ImageBenchmarks/EvictingDictionaryBenchmark.cs
+++ b/src/PicView.Benchmarks/ImageBenchmarks/EvictingDictionaryBenchmark.cs
@@ -44,7 +44,7 @@ public class EvictingDictionaryBenchmark
     {
         for (var i = 0; i < _images.Count; i++)
         {
-            _evictingDict.TryAdd(i, _images[i], _images.Count, false, out _);
+            _evictingDict.TryAdd(i, _images[i], _images.Count, false, out _, out _);
         }
     }
 }

--- a/src/PicView.Core/ArchiveHandling/ArchiveExtractionService.cs
+++ b/src/PicView.Core/ArchiveHandling/ArchiveExtractionService.cs
@@ -96,7 +96,46 @@ public class ArchiveExtractionService
                 return new ArchivePreparation(tempDirectory, files, IsFullyExtracted: true);
             }
 
-            var archive = await ArchiveFactory.OpenAsyncArchive(archivePath);
+            if (Settings.Navigation.AlwaysUncompressEntireArchive)
+            {
+                var extractedFiles = new List<string>();
+                await using (var fullArchive = await ArchiveFactory.OpenAsyncArchive(archivePath).ConfigureAwait(false))
+                {
+                    await foreach (var entry in fullArchive.EntriesAsync.ConfigureAwait(false))
+                    {
+                        if (entry.IsDirectory || string.IsNullOrEmpty(entry.Key) || !entry.Key.IsSupported())
+                        {
+                            continue;
+                        }
+
+                        try
+                        {
+                            var extractedPath = WriteEntryFlat(entry, tempDirectory);
+                            if (!string.IsNullOrEmpty(extractedPath))
+                            {
+                                extractedFiles.Add(extractedPath);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            DebugHelper.LogDebug(nameof(ArchiveExtractionService), nameof(PrepareArchiveAsync), ex);
+                        }
+                    }
+                }
+
+                if (extractedFiles.Count is 0)
+                {
+                    return null;
+                }
+
+                var filesArray = extractedFiles.ToArray();
+                SortByFileName(filesArray, stringComparer);
+
+                LastOpenedArchive = archivePath;
+                return new ArchivePreparation(tempDirectory, filesArray, IsFullyExtracted: true);
+            }
+
+            await using var archive = await ArchiveFactory.OpenAsyncArchive(archivePath);
             var entries = await archive.EntriesAsync
                 .Where(e => !e.IsDirectory
                             && !string.IsNullOrEmpty(e.Key)
@@ -185,36 +224,40 @@ public class ArchiveExtractionService
 
         try
         {
-            await Task.Run(() =>
+            var pending = new HashSet<string>(remainingKeys, StringComparer.Ordinal);
+            await using var archive = await ArchiveFactory.OpenAsyncArchive(archivePath, cancellationToken: ct).ConfigureAwait(false);
+
+            await foreach (var entry in archive.EntriesAsync.WithCancellation(ct).ConfigureAwait(false))
             {
-                var pending = new HashSet<string>(remainingKeys, StringComparer.Ordinal);
-                using var archive = ArchiveFactory.OpenArchive(archivePath);
-
-                foreach (var entry in archive.Entries)
+                if (ct.IsCancellationRequested)
                 {
-                    if (ct.IsCancellationRequested)
-                    {
-                        return;
-                    }
-
-                    if (entry.IsDirectory || string.IsNullOrEmpty(entry.Key))
-                    {
-                        continue;
-                    }
-
-                    if (!pending.Remove(entry.Key))
-                    {
-                        continue;
-                    }
-
-                    WriteEntryFlat(entry, tempDirectory);
-
-                    if (pending.Count == 0)
-                    {
-                        return;
-                    }
+                    return;
                 }
-            }, ct).ConfigureAwait(false);
+
+                if (entry.IsDirectory || string.IsNullOrEmpty(entry.Key))
+                {
+                    continue;
+                }
+
+                if (!pending.Remove(entry.Key))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    WriteEntryFlat(entry, tempDirectory);
+                }
+                catch (Exception ex)
+                {
+                    DebugHelper.LogDebug(nameof(ArchiveExtractionService), nameof(ExtractRemainingAsync), ex);
+                }
+
+                if (pending.Count == 0)
+                {
+                    return;
+                }
+            }
         }
         catch (OperationCanceledException)
         {
@@ -244,8 +287,11 @@ public class ArchiveExtractionService
             }
 
             Directory.Delete(tempZipDirectory, true);
-            TempZipDirectory = null;
-            LastOpenedArchive = null;
+            if (tempZipDirectory == TempZipDirectory)
+            {
+                TempZipDirectory = null;
+                LastOpenedArchive = null;
+            }
         }
         catch (Exception ex)
         {

--- a/src/PicView.Core/Config/AppSettings.cs
+++ b/src/PicView.Core/Config/AppSettings.cs
@@ -466,4 +466,8 @@ public class Navigation
     /// </summary>
     public bool IsNavigatingBackwardsWhenDeleting { get; set; } = true;
 
+    /// <summary>
+    /// Indicates whether all files in an archive should be extracted at once when opening an archive.
+    /// </summary>
+    public bool AlwaysUncompressEntireArchive { get; set; } = false;
 }

--- a/src/PicView.Core/Config/Languages/da.json
+++ b/src/PicView.Core/Config/Languages/da.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Gå 100 billeder frem",
   "AdvanceBy10Images": "Gå 10 billeder frem",
   "AllowZoomOut": "Undgå at zoome billedet ud, når billedet allerede er i maksimal størrelse",
+  "AlwaysUncompressEntireArchive": "Udpak altid hele arkivmappen",
   "Alt": "Alt",
   "Altitude": "Højde",
   "AperturePriority": "Blænde prioritet",

--- a/src/PicView.Core/Config/Languages/de.json
+++ b/src/PicView.Core/Config/Languages/de.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "100 Bilder vorwärts gehen",
   "AdvanceBy10Images": "10 Bilder vorwärts gehen",
   "AllowZoomOut": "Herauszoomen des Bildes vermeiden, wenn es bereits maximale Größe hat",
+  "AlwaysUncompressEntireArchive": "Gesamten Archivordner immer entpacken",
   "Alt": "Alt",
   "Altitude": "Höhe",
   "AperturePriority": "Blendenpriorität",

--- a/src/PicView.Core/Config/Languages/en.json
+++ b/src/PicView.Core/Config/Languages/en.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Advance by 100 Images",
   "AdvanceBy10Images": "Advance by 10 Images",
   "AllowZoomOut": "Avoid zooming out when it is already at maximum size",
+  "AlwaysUncompressEntireArchive": "Always uncompress entire archive folder",
   "Alt": "Alt",
   "Altitude": "Altitude",
   "AperturePriority": "Aperture priority",

--- a/src/PicView.Core/Config/Languages/es.json
+++ b/src/PicView.Core/Config/Languages/es.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Avanzar 100 imágenes",
   "AdvanceBy10Images": "Avanzar 10 imágenes",
   "AllowZoomOut": "Evite hacer zoom out en la imagen cuando ya esté en tamaño máximo",
+  "AlwaysUncompressEntireArchive": "Descomprimir siempre toda la carpeta del archivo",
   "Alt": "Alt",
   "Altitude": "Altitud",
   "AperturePriority": "Prioridad de apertura",

--- a/src/PicView.Core/Config/Languages/fr.json
+++ b/src/PicView.Core/Config/Languages/fr.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Avancer de 100 images",
   "AdvanceBy10Images": "Avancer de 10 images",
   "AllowZoomOut": "Évitez de zoomer sur l'image lorsqu'elle est déjà à sa taille maximale",
+  "AlwaysUncompressEntireArchive": "Toujours décompresser tout le dossier d'archive",
   "Alt": "Alt",
   "Altitude": "Altitude",
   "AperturePriority": "Priorité à l'ouverture",

--- a/src/PicView.Core/Config/Languages/he.json
+++ b/src/PicView.Core/Config/Languages/he.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "התקדם ב-100 תמונות",
   "AdvanceBy10Images": "התקדם ב-10 תמונות",
   "AllowZoomOut": "מנע התרחקות (זום אאוט) כשהתמונה כבר בגודל המרבי",
+  "AlwaysUncompressEntireArchive": "תמיד חלץ את כל תיקיית הארכיון",
   "Alt": "Alt",
   "Altitude": "גובה",
   "AperturePriority": "עדיפות צמצם",

--- a/src/PicView.Core/Config/Languages/hu.json
+++ b/src/PicView.Core/Config/Languages/hu.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Előrelépés 100 képpel",
   "AdvanceBy10Images": "Előrelépés 10 képpel",
   "AllowZoomOut": "Ne nagyítson, ha már maximális a kép nagyítása.",
+  "AlwaysUncompressEntireArchive": "Mindig csomagolja ki a teljes archívum mappát",
   "Alt": "Alt",
   "Altitude": "Magasság",
   "AperturePriority": "Rekeszérték elsőbbség",

--- a/src/PicView.Core/Config/Languages/it.json
+++ b/src/PicView.Core/Config/Languages/it.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Avanza di 100 immagini",
   "AdvanceBy10Images": "Avanza di 10 immagini",
   "AllowZoomOut": "Evitare lo zoom dell'immagine quando è già alla dimensione massima",
+  "AlwaysUncompressEntireArchive": "Decomprimi sempre l'intera cartella dell'archivio",
   "Alt": "Alt",
   "Altitude": "Altitudine",
   "AperturePriority": "Priorità di apertura",

--- a/src/PicView.Core/Config/Languages/ja.json
+++ b/src/PicView.Core/Config/Languages/ja.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "100画像進む",
   "AdvanceBy10Images": "10画像進む",
   "AllowZoomOut": "すでに最大サイズになっている場合はズームアウトしない",
+  "AlwaysUncompressEntireArchive": "常にアーカイブフォルダ全体を展開する",
   "Alt": "Alt",
   "Altitude": "高度",
   "AperturePriority": "絞り優先",

--- a/src/PicView.Core/Config/Languages/ko.json
+++ b/src/PicView.Core/Config/Languages/ko.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "이미지 100개 앞으로 이동",
   "AdvanceBy10Images": "이미지 10개 앞으로 이동",
   "AllowZoomOut": "이미지가 이미 최대 크기일 때는 축소하지 않음",
+  "AlwaysUncompressEntireArchive": "항상 전체 압축 파일 폴더 해제",
   "Alt": "Alt",
   "Altitude": "고도",
   "AperturePriority": "조리개 우선",

--- a/src/PicView.Core/Config/Languages/nl.json
+++ b/src/PicView.Core/Config/Languages/nl.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Vooruitgaan met 100 afbeeldingen",
   "AdvanceBy10Images": "Vooruitgaan met 10 afbeeldingen",
   "AllowZoomOut": "Niet uitzoomen als het al op maximale grootte is",
+  "AlwaysUncompressEntireArchive": "Pak altijd de gehele archiefmap uit",
   "Alt": "Alt",
   "Altitude": "Hoogte",
   "AperturePriority": "Diafragmaprioriteit",

--- a/src/PicView.Core/Config/Languages/pl.json
+++ b/src/PicView.Core/Config/Languages/pl.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Przejdź o 100 obrazów do przodu",
   "AdvanceBy10Images": "Przejdź o 10 obrazów do przodu",
   "AllowZoomOut": "Unikaj zmniejszania obrazu: gdy jest już w maksymalnym rozmiarze",
+  "AlwaysUncompressEntireArchive": "Zawsze rozpakowuj cały folder archiwum",
   "Alt": "Alt",
   "Altitude": "Wysokość",
   "AperturePriority": "Priorytet przysłony",

--- a/src/PicView.Core/Config/Languages/pt-br.json
+++ b/src/PicView.Core/Config/Languages/pt-br.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Avançar por 100 imagens",
   "AdvanceBy10Images": "Avançar por 10 imagens",
   "AllowZoomOut": "Evitar diminuir o zoom da imagem quando ela já estiver no tamanho máximo",
+  "AlwaysUncompressEntireArchive": "Sempre descompactar toda a pasta do arquivo",
   "Alt": "Alt",
   "Altitude": "Altura",
   "AperturePriority": "Prioridade de abertura",

--- a/src/PicView.Core/Config/Languages/ro.json
+++ b/src/PicView.Core/Config/Languages/ro.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Avansează cu 100 imagini",
   "AdvanceBy10Images": "Avansează cu 10 imagini",
   "AllowZoomOut": "Evitați micșorarea imaginii când aceasta este deja la dimensiunea maximă",
+  "AlwaysUncompressEntireArchive": "Decomprimă întotdeauna întregul dosar de arhivă",
   "Alt": "Alt",
   "Altitude": "Altitudine",
   "AperturePriority": "Prioritate diafragmă",

--- a/src/PicView.Core/Config/Languages/ru.json
+++ b/src/PicView.Core/Config/Languages/ru.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Продвинуться на 100 изображений вперед",
   "AdvanceBy10Images": "Продвинуться на 10 изображений вперед",
   "AllowZoomOut": "Избегать уменьшения масштаба, когда он уже максимален",
+  "AlwaysUncompressEntireArchive": "Всегда распаковывать всю папку архива",
   "Alt": "Alt",
   "Altitude": "Высота",
   "AperturePriority": "Приоритет диафрагмы",

--- a/src/PicView.Core/Config/Languages/sl.json
+++ b/src/PicView.Core/Config/Languages/sl.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Preskoči naprej za 100 slik",
   "AdvanceBy10Images": "Preskoči naprej za 10 slik",
   "AllowZoomOut": "Prepreči odmik pri maksimalni velikosti",
+  "AlwaysUncompressEntireArchive": "Vedno razpakiraj celotno mapo arhiva",
   "Alt": "Alt",
   "Altitude": "Nadmorska višina",
   "AperturePriority": "Prioriteta zaslonke",

--- a/src/PicView.Core/Config/Languages/sr-Cyrl.json
+++ b/src/PicView.Core/Config/Languages/sr-Cyrl.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Иди унапред за 100 слика",
   "AdvanceBy10Images": "Иди унапред за 10 слика",
   "AllowZoomOut": "Избегавај умањење када је зум на максималној величини",
+  "AlwaysUncompressEntireArchive": "Увек распакуј целу фасциклу архиве",
   "Alt": "Аlt",
   "Altitude": "Надморска висина",
   "AperturePriority": "Приоритет отвореног бламирања",

--- a/src/PicView.Core/Config/Languages/sr-Latn.json
+++ b/src/PicView.Core/Config/Languages/sr-Latn.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "About": "O programu",
   "ActionProgram": "Program akcije",
   "AddFiles": "Dodaj fajlove",
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Idi unapred za 100 slika",
   "AdvanceBy10Images": "Idi unapred za 10 slika",
   "AllowZoomOut": "Izbegavaj umanjenje kada je zum na maksimalnoj veličini",
+  "AlwaysUncompressEntireArchive": "Uvek raspakuj celu fasciklu arhive",
   "Alt": "Alt",
   "Altitude": "Nadmorska visina",
   "AperturePriority": "Prioritet otvorenog blamiranja",

--- a/src/PicView.Core/Config/Languages/sv.json
+++ b/src/PicView.Core/Config/Languages/sv.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "Framåt 10 bilder",
   "AdvanceBy10Images": "Framåt 100 bilder",
   "AllowZoomOut": "Undvik att zooma ut bilden när den redan är maximerad",
+  "AlwaysUncompressEntireArchive": "Packa alltid upp hela arkivmappen",
   "Alt": "Alt",
   "Altitude": "Höjd",
   "AperturePriority": "Bländarautomatik",

--- a/src/PicView.Core/Config/Languages/tr.json
+++ b/src/PicView.Core/Config/Languages/tr.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "100 görüntü ileri",
   "AdvanceBy10Images": "10 görüntü ileri",
   "AllowZoomOut": "Görüntü zaten maksimum boyuttayken görüntüyü uzaklaştırmaktan kaçın",
+  "AlwaysUncompressEntireArchive": "Tüm arşiv klasörünü her zaman ayıkla",
   "Alt": "Alt",
   "Altitude": "İrtifa",
   "AperturePriority": "Diyafram önceliği",

--- a/src/PicView.Core/Config/Languages/zh-CN.json
+++ b/src/PicView.Core/Config/Languages/zh-CN.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "前进 100 张图片",
   "AdvanceBy10Images": "前进 10 张图片",
   "AllowZoomOut": "在最大尺寸时避免缩小图像",
+  "AlwaysUncompressEntireArchive": "总是解压整个压缩包文件夹",
   "Alt": "Alt",
   "Altitude": "海拔",
   "AperturePriority": "光圈优先",

--- a/src/PicView.Core/Config/Languages/zh-TW.json
+++ b/src/PicView.Core/Config/Languages/zh-TW.json
@@ -12,6 +12,7 @@
   "AdvanceBy100Images": "前進 100 張圖片",
   "AdvanceBy10Images": "前進 10 張圖片",
   "AllowZoomOut": "在圖片已達最大尺寸時，不要縮小圖片",
+  "AlwaysUncompressEntireArchive": "總解壓縮整個壓縮檔資料夾",
   "Alt": "Alt",
   "Altitude": "海拔",
   "AperturePriority": "光圈優先",

--- a/src/PicView.Core/Localization/LanguageModel.cs
+++ b/src/PicView.Core/Localization/LanguageModel.cs
@@ -24,6 +24,7 @@ public class LanguageModel
     public string? AdvanceBy100Images { get; set; }
     public string? AdvanceBy10Images { get; set; }
     public string? AllowZoomOut { get; set; }
+    public string? AlwaysUncompressEntireArchive { get; set; }
     public string? Alt { get; set; }
     public string? Altitude { get; set; }
     public string? AperturePriority { get; set; }

--- a/src/PicView.Core/Navigation/NavigationService.cs
+++ b/src/PicView.Core/Navigation/NavigationService.cs
@@ -52,33 +52,53 @@ public class NavigationService(
             {
                 model = await imageLoader.GetImageModelAsync(fileInfo, ct.Token).ConfigureAwait(false);
             }
+            tab.ImageIterator.Files = files ?? FileListRetriever.RetrieveFiles(fileInfo, stringComparer);
+            index = FindIndex(fileInfo, tab);
+            if (index < 0 && tab.ImageIterator.Files.Count > 0)
+            {
+                index = 0;
+            }
+            tab.ImageIterator.Initialize(tab.ImageIterator.Files, index);
+
             if (Settings.ImageScaling.ShowImageSideBySide)
             {
-                tab.ImageIterator.Files = files ?? FileListRetriever.RetrieveFiles(fileInfo, stringComparer);
-                index = FindIndex(fileInfo, tab);
-                var (_, nextIteration, _) = IterationHelper.GetIterations(index, tab.ImageIterator.Files.Count, NavigateTo.Next, SkipAmount.None);
-                var secondaryFileInfo = tab.ImageIterator.Files[nextIteration];
-                if (cache.TryGet(secondaryFileInfo, out var secondaryPreLoadValue))
+                if (tab.ImageIterator.Files.Count > 0 && index >= 0)
                 {
-                    secondaryModel = secondaryPreLoadValue.ImageModel;
+                    var (_, nextIteration, _) = IterationHelper.GetIterations(index, tab.ImageIterator.Files.Count, NavigateTo.Next, SkipAmount.None);
+                    if (nextIteration >= 0 && nextIteration < tab.ImageIterator.Files.Count)
+                    {
+                        var secondaryFileInfo = tab.ImageIterator.Files[nextIteration];
+                        if (cache.TryGet(secondaryFileInfo, out var secondaryPreLoadValue))
+                        {
+                            secondaryModel = secondaryPreLoadValue.ImageModel;
+                        }
+                        else
+                        {
+                            secondaryModel = await imageLoader.GetImageModelAsync(secondaryFileInfo, ct.Token).ConfigureAwait(false);
+                        }
+                        tab.SecondaryModel = secondaryModel;
+                        tab.SecondaryImage.Value = secondaryModel.Image;
+                        tab.SecondaryImageType.Value = secondaryModel.ImageType;
+                        tab.SecondaryFileInfo.Value = secondaryFileInfo;
+                        secondaryIndex = nextIteration;
+                    }
+                    else
+                    {
+                        tab.SecondaryModel = null;
+                        tab.SecondaryImage.Value = null;
+                        tab.SecondaryImageType.Value = null;
+                        tab.SecondaryFileInfo.Value = null;
+                    }
                 }
-                else
-                {
-                    secondaryModel = await imageLoader.GetImageModelAsync(secondaryFileInfo, ct.Token).ConfigureAwait(false);
-                }
-                tab.SecondaryModel = secondaryModel;
-                tab.SecondaryImage.Value = secondaryModel.Image;
-                tab.SecondaryImageType.Value = secondaryModel.ImageType;
-                tab.SecondaryFileInfo.Value = secondaryFileInfo;
                 ShowModel(model);
-                secondaryIndex = nextIteration;
             }
             else
             {
+                tab.SecondaryModel = null;
+                tab.SecondaryImage.Value = null;
+                tab.SecondaryImageType.Value = null;
+                tab.SecondaryFileInfo.Value = null;
                 ShowModel(model);
-                tab.ImageIterator.Files = files ?? FileListRetriever.RetrieveFiles(fileInfo, stringComparer);
-                index = FindIndex(fileInfo, tab);
-                tab.ImageIterator.SetCurrentIndex(index);
             }
             
             tab.UpdateTabTitle();
@@ -87,7 +107,7 @@ public class NavigationService(
             cache.Add(tab.Id, index, new PreLoadValue(model), tab.ImageIterator.Files.Count, false);
             if (secondaryModel is not null)
             {
-                cache.Add(tab.Id, secondaryIndex, new PreLoadValue(model), tab.ImageIterator.Files.Count, false);
+                cache.Add(tab.Id, secondaryIndex, new PreLoadValue(secondaryModel), tab.ImageIterator.Files.Count, false);
             }
             cache.Preload(tab.Id, index, false, tab.ImageIterator.Files, tab.GetTabCancellation().Token);
             FileHistoryManager.Add(fileInfo.FullName);
@@ -132,6 +152,12 @@ public class NavigationService(
         if (!fileInfo.Exists)
         {
             DebugHelper.LogDebug(nameof(NavigationService), nameof(LoadFromFileAsync), $"Attempted to load a file that does not exist: {fileInfo}");
+            return;
+        }
+
+        if (fileInfo.FullName.IsArchive())
+        {
+            await LoadFromArchiveAsync(fileInfo.FullName, tab, ct).ConfigureAwait(false);
             return;
         }
         var iterator = tab.ImageIterator;
@@ -226,86 +252,94 @@ public class NavigationService(
         {
             return false;
         }
-        
-        // Retrieve the temporary directory for the possible previous archive extraction
-        var tempZipDir = tab.ArchiveExtractionService.TempZipDirectory;
 
-        var preparation = await tab.ArchiveExtractionService.PrepareArchiveAsync(
-            archivePath,
-            platformService.ExtractWithLocalSoftwareAsync,
-            stringComparer).ConfigureAwait(false);
+        tab.SetLoading();
 
-        if (preparation is null || string.IsNullOrEmpty(tab.ArchiveExtractionService.TempZipDirectory))
+        try
         {
-            return false;
-        }
+            // Retrieve the temporary directory for the possible previous archive extraction
+            var tempZipDir = tab.ArchiveExtractionService.TempZipDirectory;
 
-        if (ct.IsCancellationRequested)
-        {
-            return false;
-        }
+            var preparation = await tab.ArchiveExtractionService.PrepareArchiveAsync(
+                archivePath,
+                platformService.ExtractWithLocalSoftwareAsync,
+                stringComparer).ConfigureAwait(false);
 
-        var prep = preparation.Value;
-
-        if (prep.IsFullyExtracted)
-        {
-            // Local-software extractor already wrote every file to disk; build the file list
-            // from the already-extracted paths so we don't depend on FileListRetriever's
-            // recursion settings.
-            var allFiles = prep.EntryKeys.Select(p => new FileInfo(p)).ToList();
-            if (allFiles.Count is 0)
+            if (preparation is null || string.IsNullOrEmpty(tab.ArchiveExtractionService.TempZipDirectory))
             {
                 return false;
             }
 
-            await RepopulateIterator(allFiles[0], tab, ct, allFiles).ConfigureAwait(false);
+            if (ct.IsCancellationRequested)
+            {
+                return false;
+            }
 
-            FileHistoryManager.Add(archivePath);
+            var prep = preparation.Value;
+
+            if (prep.IsFullyExtracted)
+            {
+                // Local-software extractor already wrote every file to disk; build the file list
+                // from the already-extracted paths so we don't depend on FileListRetriever's
+                // recursion settings.
+                var allFiles = prep.EntryKeys.Select(p => new FileInfo(p)).ToList();
+                if (allFiles.Count is 0)
+                {
+                    return false;
+                }
+
+                await RepopulateIterator(allFiles[0], tab, ct, allFiles).ConfigureAwait(false);
+
+                FileHistoryManager.Add(archivePath);
+                tab.ArchiveExtractionService.Cleanup(tempZipDir);
+                return true;
+            }
+
+            // Staged extraction: extract the first entry, navigate to it, then extract the rest in
+            // the background while FileWatcherService inserts each new file into the iterator.
+            var firstKey = prep.EntryKeys[0];
+            var firstPath = await tab.ArchiveExtractionService.ExtractEntryAsync(archivePath, firstKey, ct.Token).ConfigureAwait(false);
+
+            if (string.IsNullOrEmpty(firstPath) || ct.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            if (Settings.ImageScaling.ShowImageSideBySide && prep.EntryKeys.Length > 1)
+            {
+                var secondKey = prep.EntryKeys[1];
+                var secondPath = await tab.ArchiveExtractionService.ExtractEntryAsync(archivePath, secondKey, ct.Token).ConfigureAwait(false);
+                var seedFiles = new List<FileInfo>
+                {
+                    new(firstPath),
+                    new(secondPath)
+                };
+                await RepopulateIterator(seedFiles[0], tab, ct, seedFiles).ConfigureAwait(false);
+            }
+            else
+            {
+                // Seed the iterator with just the first extracted file. Watching the temp directory
+                // first ensures every subsequent file creation event is captured by FileWatcherService
+                // and inserted in sorted order into the iterator/gallery.
+                var seedFiles = new List<FileInfo> { new(firstPath) };
+                await RepopulateIterator(seedFiles[0], tab, ct, seedFiles).ConfigureAwait(false);
+            }
+
+
+            // Kick off background extraction of remaining entries. FileWatcherService picks them up.
+            if (prep.EntryKeys.Length > 1)
+            {
+                var remainingKeys = prep.EntryKeys.Skip(1).ToArray();
+                var backgroundToken = tab.GetTabCancellation().Token;
+                _ = Task.Run(() => tab.ArchiveExtractionService.ExtractRemainingAsync(archivePath, remainingKeys, backgroundToken), backgroundToken);
+            }
+
+            tab.ArchiveExtractionService.Cleanup(tempZipDir);
             return true;
         }
-
-        // Staged extraction: extract the first entry, navigate to it, then extract the rest in
-        // the background while FileWatcherService inserts each new file into the iterator.
-        var firstKey = prep.EntryKeys[0];
-        var firstPath = await tab.ArchiveExtractionService.ExtractEntryAsync(archivePath, firstKey, ct.Token).ConfigureAwait(false);
-
-        if (string.IsNullOrEmpty(firstPath) || ct.IsCancellationRequested)
+        finally
         {
-            return false;
         }
-
-        if (Settings.ImageScaling.ShowImageSideBySide && prep.EntryKeys.Length > 1)
-        {
-            var secondKey = prep.EntryKeys[1];
-            var secondPath = await tab.ArchiveExtractionService.ExtractEntryAsync(archivePath, secondKey, ct.Token).ConfigureAwait(false);
-            var seedFiles = new List<FileInfo>
-            {
-                new(firstPath),
-                new(secondPath)
-            };
-            await RepopulateIterator(seedFiles[0], tab, ct, seedFiles).ConfigureAwait(false);
-        }
-        else
-        {
-            // Seed the iterator with just the first extracted file. Watching the temp directory
-            // first ensures every subsequent file creation event is captured by FileWatcherService
-            // and inserted in sorted order into the iterator/gallery.
-            var seedFiles = new List<FileInfo> { new(firstPath) };
-            await RepopulateIterator(seedFiles[0], tab, ct, seedFiles).ConfigureAwait(false);
-        }
-
-
-        // Kick off background extraction of remaining entries. FileWatcherService picks them up.
-        if (prep.EntryKeys.Length > 1)
-        {
-            var remainingKeys = prep.EntryKeys.Skip(1).ToArray();
-            var backgroundToken = tab.GetTabCancellation().Token;
-            _ = Task.Run(() => tab.ArchiveExtractionService.ExtractRemainingAsync(archivePath, remainingKeys, backgroundToken), backgroundToken);
-        }
-
-        FileHistoryManager.Add(archivePath);
-        tab.ArchiveExtractionService.Cleanup(tempZipDir);
-        return true;
     }
 
     public async ValueTask LoadFromBase64Async(string source, TabViewModel tab, CancellationTokenSource ct)

--- a/src/PicView.Core/Search/SettingsSearchData.cs
+++ b/src/PicView.Core/Search/SettingsSearchData.cs
@@ -28,6 +28,7 @@ public class SettingsSearchData
     public string NavigationLoopSearchTags { get; }
     public string NavigationTaskbarSearchTags { get; }
     public string NavigationSpeedSearchTags { get; }
+    public string NavigationArchiveSearchTags { get; }
     public string GalleryVisibilitySearchTags { get; }
     public string GalleryDockSearchTags { get; }
     public string GallerySizeSearchTags { get; }
@@ -255,6 +256,15 @@ public class SettingsSearchData
         sb.Append(space);
         sb.Append("Speed Time");
         NavigationSpeedSearchTags = sb.ToString();
+        
+        sb.Clear();
+        
+        sb.Append(TranslationManager.Translation.Navigation);
+        sb.Append(space);
+        sb.Append(TranslationManager.Translation.AlwaysUncompressEntireArchive);
+        sb.Append(space);
+        sb.Append("Archive Extract Zip Uncompress");
+        NavigationArchiveSearchTags = sb.ToString();
         
         sb.Clear();
         

--- a/src/PicView.Core/Search/SettingsSearchIndex.cs
+++ b/src/PicView.Core/Search/SettingsSearchIndex.cs
@@ -102,6 +102,8 @@ public static class SettingsSearchIndex
             list.Add(new SettingsSearchItem(t.ToggleTaskbarProgress, data.NavigationTaskbarSearchTags));
         if (t.AdjustNavSpeed != null)
             list.Add(new SettingsSearchItem(t.AdjustNavSpeed, data.NavigationSpeedSearchTags));
+        if (t.AlwaysUncompressEntireArchive != null)
+            list.Add(new SettingsSearchItem(t.AlwaysUncompressEntireArchive, data.NavigationArchiveSearchTags));
 
         // Gallery
         if (t.ShowDockedGallery != null)

--- a/src/PicView.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PicView.Core/ViewModels/SettingsViewModel.cs
@@ -83,6 +83,7 @@ public class SettingsViewModel : IDisposable
         IsIncludingSubdirectories.Subscribe(x => Settings.Sorting.IncludeSubDirectories = x).AddTo(ref _disposables);
         IsShowingTaskbarProgress.Subscribe(x => Settings.UIProperties.IsTaskbarProgressEnabled = x).AddTo(ref _disposables);
         IsFileHistoryEnabled.Subscribe(x => Settings.Navigation.IsFileHistoryEnabled = x).AddTo(ref _disposables);
+        IsUncompressingEntireArchive.Subscribe(x => Settings.Navigation.AlwaysUncompressEntireArchive = x).AddTo(ref _disposables);
         
         ToggleUsingTouchpadCommand = new ReactiveCommand(_ =>
         {
@@ -217,6 +218,7 @@ public class SettingsViewModel : IDisposable
     public BindableReactiveProperty<bool> IsIncludingSubdirectories { get; } = new(Settings.Sorting.IncludeSubDirectories);
     public BindableReactiveProperty<bool> IsShowingTaskbarProgress { get; } = new(Settings.UIProperties.IsTaskbarProgressEnabled);
     public BindableReactiveProperty<bool> IsFileHistoryEnabled { get; } = new(Settings.Navigation.IsFileHistoryEnabled);
+    public BindableReactiveProperty<bool> IsUncompressingEntireArchive { get; } = new(Settings.Navigation.AlwaysUncompressEntireArchive);
     public BindableReactiveProperty<bool> IsShowingFullPathInTitleBar { get; } = new(Settings.UIProperties.ShowFullPathInTitleBar);
 
     public BindableReactiveProperty<bool> IsShowingRecycleDialog { get; } =
@@ -327,6 +329,7 @@ public class SettingsViewModel : IDisposable
             IsIncludingSubdirectories,
             IsShowingTaskbarProgress,
             IsFileHistoryEnabled,
+            IsUncompressingEntireArchive,
             SetColorThemeCommand,
             SetBackgroundCommand,
             ToggleUsingTouchpadCommand,

--- a/src/PicView.Core/ViewModels/TranslationViewModel.cs
+++ b/src/PicView.Core/ViewModels/TranslationViewModel.cs
@@ -29,6 +29,7 @@ public class TranslationViewModel
         AdvanceBy10Images.Value = t.AdvanceBy10Images;
         AdvanceBy100Images.Value = t.AdvanceBy100Images;
         AllowZoomOut.Value = t.AllowZoomOut;
+        AlwaysUncompressEntireArchive.Value = t.AlwaysUncompressEntireArchive;
         Altitude.Value = t.Altitude;
         Appearance.Value = t.Appearance;
         ApplicationShortcuts.Value = t.ApplicationShortcuts;
@@ -415,6 +416,7 @@ public class TranslationViewModel
     public BindableReactiveProperty<string?> AdvanceBy100Images { get; } = new();
     public BindableReactiveProperty<string?> AdvanceBy10Images { get; } = new();
     public BindableReactiveProperty<string?> AllowZoomOut { get; } = new();
+    public BindableReactiveProperty<string?> AlwaysUncompressEntireArchive { get; } = new();
     public BindableReactiveProperty<string?> Altitude { get; } = new();
     public BindableReactiveProperty<string?> Appearance { get; } = new();
     public BindableReactiveProperty<string?> ApplicationShortcuts { get; } = new();

--- a/src/PicView.Tests/ArchiveHandling/ArchiveExtractionServiceTests.cs
+++ b/src/PicView.Tests/ArchiveHandling/ArchiveExtractionServiceTests.cs
@@ -80,6 +80,106 @@ public class ArchiveExtractionServiceTests
         Assert.Null(result);
     }
 
+    [Fact]
+    public async Task PrepareArchiveAsync_AlwaysUncompressEntireArchive_ExtractsAllFilesAndReturnsFullyExtracted()
+    {
+        var tempZipPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.zip");
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var file1 = Path.Combine(tempDir, "test1.jpg");
+            var file2 = Path.Combine(tempDir, "test2.png");
+            File.WriteAllBytes(file1, new byte[] { 0xFF, 0xD8, 0xFF });
+            File.WriteAllBytes(file2, new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+
+            System.IO.Compression.ZipFile.CreateFromDirectory(tempDir, tempZipPath);
+
+            var service = new ArchiveExtractionService();
+
+            // Test default (false)
+            Settings.Navigation.AlwaysUncompressEntireArchive = false;
+            var resultFalse = await service.PrepareArchiveAsync(
+                tempZipPath,
+                (_, _) => Task.FromResult(false),
+                string.Compare);
+
+            Assert.NotNull(resultFalse);
+            Assert.False(resultFalse.Value.IsFullyExtracted);
+            Assert.Equal(2, resultFalse.Value.EntryKeys.Length);
+            service.Cleanup();
+
+            // Test AlwaysUncompressEntireArchive = true
+            Settings.Navigation.AlwaysUncompressEntireArchive = true;
+            var resultTrue = await service.PrepareArchiveAsync(
+                tempZipPath,
+                (_, _) => Task.FromResult(false),
+                string.Compare);
+
+            Assert.NotNull(resultTrue);
+            Assert.True(resultTrue.Value.IsFullyExtracted);
+            Assert.Equal(2, resultTrue.Value.EntryKeys.Length);
+            Assert.True(File.Exists(resultTrue.Value.EntryKeys[0]));
+            Assert.True(File.Exists(resultTrue.Value.EntryKeys[1]));
+            service.Cleanup();
+        }
+        finally
+        {
+            Settings.Navigation.AlwaysUncompressEntireArchive = false;
+            if (File.Exists(tempZipPath)) File.Delete(tempZipPath);
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task PrepareArchiveAsync_MultipleArchivesSequential_CleansUpAndSucceeds()
+    {
+        var tempZipPath1 = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.zip");
+        var tempZipPath2 = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.zip");
+        var tempDir1 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempDir2 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir1);
+        Directory.CreateDirectory(tempDir2);
+
+        try
+        {
+            File.WriteAllBytes(Path.Combine(tempDir1, "a.jpg"), new byte[] { 0xFF, 0xD8, 0xFF });
+            File.WriteAllBytes(Path.Combine(tempDir2, "b.png"), new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+
+            System.IO.Compression.ZipFile.CreateFromDirectory(tempDir1, tempZipPath1);
+            System.IO.Compression.ZipFile.CreateFromDirectory(tempDir2, tempZipPath2);
+
+            Settings.Navigation.AlwaysUncompressEntireArchive = true;
+            var service = new ArchiveExtractionService();
+
+            // First archive
+            var res1 = await service.PrepareArchiveAsync(tempZipPath1, (_, _) => Task.FromResult(false), string.Compare);
+            Assert.NotNull(res1);
+            Assert.True(res1.Value.IsFullyExtracted);
+            var firstTempDir = service.TempZipDirectory;
+
+            // Second archive
+            var res2 = await service.PrepareArchiveAsync(tempZipPath2, (_, _) => Task.FromResult(false), string.Compare);
+            Assert.NotNull(res2);
+            Assert.True(res2.Value.IsFullyExtracted);
+
+            // Cleanup previous temp dir
+            service.Cleanup(firstTempDir);
+            Assert.False(Directory.Exists(firstTempDir));
+
+            service.Cleanup();
+        }
+        finally
+        {
+            Settings.Navigation.AlwaysUncompressEntireArchive = false;
+            if (File.Exists(tempZipPath1)) File.Delete(tempZipPath1);
+            if (File.Exists(tempZipPath2)) File.Delete(tempZipPath2);
+            if (Directory.Exists(tempDir1)) Directory.Delete(tempDir1, true);
+            if (Directory.Exists(tempDir2)) Directory.Delete(tempDir2, true);
+        }
+    }
+
     #endregion
 
     #region ExtractEntryAsync


### PR DESCRIPTION
This is my first PR for this repo, let me know if you want anything changed.

## Description

- Introduce a new Navigation setting AlwaysUncompressEntireArchive with a toggle in the Navigation settings UI and localization entries for all languages. 

- ArchiveExtractionService now supports fully extracting an archive when the setting is enabled (async extraction, safer error handling, and improved cleanup). 

- NavigationService updated to detect archives, seed iterators, handle side-by-side preloading, and kick off background extraction.

- UI improvements: show/hide loading indicator during file/archive open (FilePicker, DragAndDrop). 

- Added search tags/indexing, wired settings and translation viewmodels, 

- Fixed EvictingDictionary.TryAdd call signature (new required parameter)

- Added unit tests for full-extract behavior and sequential archive cleanup.

## Motivation and Context
Loading .cbz / .cbr from a network drive was very slow, with 1/2 second per page change, even over wired 1gbit.  This optional (defaulted off) change will uncompress the entire archive during loading, so you can page through with no lag.

## How Has This Been Tested?
Yes, all tests pass and it was manually verified in the UI.  New unit tests have been added to cover.

## Screenshots (if appropriate):
<img width="1508" height="1084" alt="image" src="https://github.com/user-attachments/assets/58c229d9-4001-45d6-ada5-9f59fe659442" />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
