### PR TITLE
Enhance batch archive extraction and improve navigation UX

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,4 +1,4 @@
-﻿# PicView Development Guidelines
+# PicView Development Guidelines
 
 ## Build & Configuration
 
@@ -27,6 +27,8 @@ dotnet build PicView.Tests\PicView.Tests.csproj
 - **InternalsVisibleTo**: `PicView.Core` exposes internals to `PicView.Tests`.
 
 ### Running Tests
+
+- **Agent Guideline**: When running `dotnet test`, never schedule polling/timeout timers (`schedule`). Allow background execution to complete indefinitely and rely on reactive task completion notifications.
 
 Run all tests:
 

--- a/src/PicView.Avalonia/FileSystem/FilePickerService.cs
+++ b/src/PicView.Avalonia/FileSystem/FilePickerService.cs
@@ -73,11 +73,8 @@ public class FilePickerService(IStorageProvider? storageProvider = null)
 
     public async Task<string?> SelectFile()
     {
-        return await Dispatcher.UIThread.InvokeAsync(async () =>
-        {
-            var file = await SelectIStorageFile().ConfigureAwait(false);
-            return file?.Path.LocalPath;
-        });
+        var file = await SelectIStorageFile().ConfigureAwait(false);
+        return file?.Path.LocalPath;
     }
 
     private async Task<IStorageFile?> SelectIStorageFile()
@@ -174,26 +171,23 @@ public class FilePickerService(IStorageProvider? storageProvider = null)
 
     public async Task<string> SelectDirectory()
     {
-        return await Dispatcher.UIThread.InvokeAsync(async () =>
+        var provider = GetStorageProvider();
+        if (provider is null) return string.Empty;
+
+        var options = new FolderPickerOpenOptions
         {
-            var provider = GetStorageProvider();
-            if (provider is null) return string.Empty;
-    
-            var options = new FolderPickerOpenOptions
-            {
-                Title = StringExtensions.CombineWithAppName(TranslationManager.Translation.Folder),
-                AllowMultiple = false
-            };
-            
-            var directories = await ExecuteOnUIThread(() => provider.OpenFolderPickerAsync(options));
-            
-            if (directories is null || directories.Count <= 0)
-            {
-                return string.Empty;
-            }
-            
-            return directories[0].Path.LocalPath;
-        });
+            Title = StringExtensions.CombineWithAppName(TranslationManager.Translation.Folder),
+            AllowMultiple = false
+        };
+        
+        var directories = await ExecuteOnUIThread(() => provider.OpenFolderPickerAsync(options)).ConfigureAwait(false);
+        
+        if (directories is null || directories.Count <= 0)
+        {
+            return string.Empty;
+        }
+        
+        return directories[0].Path.LocalPath;
     }
     
     private IStorageProvider? GetStorageProvider()
@@ -228,7 +222,10 @@ public class FilePickerService(IStorageProvider? storageProvider = null)
     
     private static async Task<T> ExecuteOnUIThread<T>(Func<Task<T>> action)
     {
-        // Try to use file picker in Dispatcher #228
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            return await action().ConfigureAwait(false);
+        }
         return await Dispatcher.UIThread.InvokeAsync(action).ConfigureAwait(false);
     }
 }

--- a/src/PicView.Avalonia/FileSystem/FileSavingService.cs
+++ b/src/PicView.Avalonia/FileSystem/FileSavingService.cs
@@ -56,7 +56,14 @@ public class FileSavingService(FilePickerService? filePickerService = null)
 
     public async ValueTask<bool> SaveFileAsync(string? filename, string destination, MainWindowViewModel vm)
     {
-        var core = await Dispatcher.UIThread.InvokeAsync(() => Application.Current?.DataContext as CoreViewModel);
+        if (Application.Current is null)
+        {
+            return false;
+        }
+
+        var core = Dispatcher.UIThread.CheckAccess()
+            ? Application.Current.DataContext as CoreViewModel
+            : await Dispatcher.UIThread.InvokeAsync(() => Application.Current.DataContext as CoreViewModel);
         if (core is null)
         {
             return false;

--- a/src/PicView.Avalonia/Input/MainKeyboardShortcuts.cs
+++ b/src/PicView.Avalonia/Input/MainKeyboardShortcuts.cs
@@ -98,7 +98,7 @@ public static class MainKeyboardShortcuts
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            if (CurrentKeys.Key is Key.LeftAlt or Key.RightAlt)
+            if (CurrentKeys?.Key is Key.LeftAlt or Key.RightAlt)
             {
                 mainWindowViewModel.TopTitlebarViewModel.ToggleMenu();
             }

--- a/src/PicView.Avalonia/Views/Main/MainView.axaml
+++ b/src/PicView.Avalonia/Views/Main/MainView.axaml
@@ -1113,7 +1113,7 @@
             BorderThickness="1"
             CornerRadius="4"
             IsHitTestVisible="False"
-            IsVisible="{Binding WindowTabs.ActiveTab.Value.IsArchiveExtracting.Value, Mode=OneWay}"
+            IsVisible="{Binding WindowTabs.ActiveTab.Value.ArchiveExtractionProgressText.Value, Mode=OneWay, Converter={x:Static ObjectConverters.IsNotNull}}"
             ZIndex="10">
             <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
                 <Viewbox Width="14" Height="14" VerticalAlignment="Center">

--- a/src/PicView.Avalonia/Views/Main/MainView.axaml
+++ b/src/PicView.Avalonia/Views/Main/MainView.axaml
@@ -1101,5 +1101,30 @@
             VerticalAlignment="Center"
             Opacity="0"
             ZIndex="9" />
+
+        <!-- Bottom-right Archive Extraction Progress Indicator -->
+        <Border
+            Margin="0,0,16,16"
+            Padding="8,4"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Bottom"
+            Background="{DynamicResource AltBackgroundColor}"
+            BorderBrush="{DynamicResource MainBorderColor}"
+            BorderThickness="1"
+            CornerRadius="4"
+            IsHitTestVisible="False"
+            IsVisible="{Binding WindowTabs.ActiveTab.Value.IsArchiveExtracting.Value, Mode=OneWay}"
+            ZIndex="10">
+            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                <Viewbox Width="14" Height="14" VerticalAlignment="Center">
+                    <uc:SpinWaiter />
+                </Viewbox>
+                <TextBlock
+                    Classes="txt"
+                    VerticalAlignment="Center"
+                    FontSize="12"
+                    Text="{Binding WindowTabs.ActiveTab.Value.ArchiveExtractionProgressText.Value, Mode=OneWay}" />
+            </StackPanel>
+        </Border>
     </Panel>
 </UserControl>

--- a/src/PicView.Core/ArchiveHandling/ArchiveExtractionService.cs
+++ b/src/PicView.Core/ArchiveHandling/ArchiveExtractionService.cs
@@ -224,52 +224,71 @@ public class ArchiveExtractionService
 
     /// <summary>
     ///     Extracts every entry whose key is present in <paramref name="remainingKeys" /> to the
-    ///     <see cref="TempZipDirectory" />. The archive is opened once and walked in its native
-    ///     order, which avoids reopening overhead.
+    ///     <see cref="TempZipDirectory" /> in batches with low priority. The archive is opened once and walked in its native
+    ///     order, reporting extraction count progress after each batch.
     /// </summary>
-    public async Task ExtractRemainingAsync(
+    public void ExtractRemaining(
         string archivePath,
         IReadOnlyCollection<string> remainingKeys,
+        int initialCount = 0,
+        int totalCount = 0,
+        IProgress<int>? progress = null,
+        int batchSize = 10,
         CancellationToken ct = default)
     {
         var tempDirectory = TempZipDirectory;
-        if (string.IsNullOrEmpty(tempDirectory) || remainingKeys.Count == 0)
+        if (string.IsNullOrEmpty(tempDirectory) || remainingKeys is null || remainingKeys.Count == 0)
         {
             return;
         }
 
         try
         {
-            await Task.Run(() =>
+            var pending = new HashSet<string>(remainingKeys, StringComparer.Ordinal);
+            using var archive = ArchiveFactory.OpenArchive(archivePath);
+
+            var extractedCount = initialCount;
+            var batchCounter = 0;
+
+            foreach (var entry in archive.Entries)
             {
-                var pending = new HashSet<string>(remainingKeys, StringComparer.Ordinal);
-                using var archive = ArchiveFactory.OpenArchive(archivePath);
-
-                foreach (var entry in archive.Entries)
+                if (ct.IsCancellationRequested)
                 {
-                    if (ct.IsCancellationRequested)
-                    {
-                        return;
-                    }
-
-                    if (entry.IsDirectory || string.IsNullOrEmpty(entry.Key))
-                    {
-                        continue;
-                    }
-
-                    if (!pending.Remove(entry.Key))
-                    {
-                        continue;
-                    }
-
-                    WriteEntryFlat(entry, tempDirectory);
-
-                    if (pending.Count == 0)
-                    {
-                        return;
-                    }
+                    return;
                 }
-            }, ct).ConfigureAwait(false);
+
+                if (entry.IsDirectory || string.IsNullOrEmpty(entry.Key))
+                {
+                    continue;
+                }
+
+                if (!pending.Remove(entry.Key))
+                {
+                    continue;
+                }
+
+                WriteEntryFlat(entry, tempDirectory);
+                extractedCount++;
+                batchCounter++;
+
+                // Yield CPU to higher-priority UI and navigation threads
+                Thread.Yield();
+
+                // Report progress after each batch or upon completing extraction
+                if (batchCounter >= batchSize || pending.Count == 0)
+                {
+                    batchCounter = 0;
+                    progress?.Report(extractedCount);
+
+                    // Brief pause between batches to give foreground operations maximum CPU/IO priority
+                    Thread.Sleep(5);
+                }
+
+                if (pending.Count == 0)
+                {
+                    return;
+                }
+            }
         }
         catch (OperationCanceledException)
         {
@@ -277,8 +296,55 @@ public class ArchiveExtractionService
         }
         catch (Exception ex)
         {
-            DebugHelper.LogDebug(nameof(ArchiveExtractionService), nameof(ExtractRemainingAsync), ex);
+            DebugHelper.LogDebug(nameof(ArchiveExtractionService), nameof(ExtractRemaining), ex);
         }
+    }
+
+    /// <summary>
+    ///     Asynchronously extracts remaining archive entries on a lowest-priority background thread.
+    /// </summary>
+    public Task ExtractRemainingAsync(
+        string archivePath,
+        IReadOnlyCollection<string> remainingKeys,
+        int initialCount = 0,
+        int totalCount = 0,
+        IProgress<int>? progress = null,
+        int batchSize = 10,
+        CancellationToken ct = default)
+    {
+        var tcs = new TaskCompletionSource();
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                ExtractRemaining(archivePath, remainingKeys, initialCount, totalCount, progress, batchSize, ct);
+                tcs.TrySetResult();
+            }
+            catch (Exception ex)
+            {
+                tcs.TrySetException(ex);
+            }
+        })
+        {
+            IsBackground = true,
+            Priority = ThreadPriority.Lowest,
+            Name = "ArchiveExtractionWorker"
+        };
+        thread.Start();
+        return tcs.Task;
+    }
+
+    private CancellationTokenSource? _extractionCts;
+
+    /// <summary>
+    ///     Resets and returns a dedicated cancellation token for background extraction operations.
+    /// </summary>
+    public CancellationToken ResetExtractionCts()
+    {
+        _extractionCts?.Cancel();
+        _extractionCts?.Dispose();
+        _extractionCts = new CancellationTokenSource();
+        return _extractionCts.Token;
     }
 
     /// <summary>
@@ -293,6 +359,10 @@ public class ArchiveExtractionService
     {
         try
         {
+            _extractionCts?.Cancel();
+            _extractionCts?.Dispose();
+            _extractionCts = null;
+
             if (string.IsNullOrEmpty(tempZipDirectory) || !Directory.Exists(tempZipDirectory))
             {
                 return;

--- a/src/PicView.Core/ArchiveHandling/ArchiveExtractionService.cs
+++ b/src/PicView.Core/ArchiveHandling/ArchiveExtractionService.cs
@@ -100,70 +100,105 @@ public class ArchiveExtractionService
                 return new ArchivePreparation(tempDirectory, files, IsFullyExtracted: true);
             }
 
-            if (Settings.Navigation.AlwaysUncompressEntireArchive)
-            {
-                var extractedFiles = new List<string>();
-                var fullArchive = await ArchiveFactory.OpenAsyncArchive(archivePath).ConfigureAwait(false);
-                await using (fullArchive.ConfigureAwait(false))
-                {
-                    await foreach (var entry in fullArchive.EntriesAsync.ConfigureAwait(false))
-                    {
-                        if (entry.IsDirectory || string.IsNullOrEmpty(entry.Key) || !entry.Key.IsSupported())
-                        {
-                            continue;
-                        }
-
-                        try
-                        {
-                            var extractedPath = WriteEntryFlat(entry, tempDirectory);
-                            if (!string.IsNullOrEmpty(extractedPath))
-                            {
-                                extractedFiles.Add(extractedPath);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            DebugHelper.LogDebug(nameof(ArchiveExtractionService), nameof(PrepareArchiveAsync), ex);
-                        }
-                    }
-                }
-
-                if (extractedFiles.Count is 0)
-                {
-                    return null;
-                }
-
-                var filesArray = extractedFiles.ToArray();
-                SortByFileName(filesArray, stringComparer);
-
-                LastOpenedArchive = archivePath;
-                return new ArchivePreparation(tempDirectory, filesArray, IsFullyExtracted: true);
-            }
-
             var archive = await ArchiveFactory.OpenAsyncArchive(archivePath).ConfigureAwait(false);
             await using (archive.ConfigureAwait(false))
             {
                 var entries = await archive.EntriesAsync
-                .Where(e => !e.IsDirectory
-                            && !string.IsNullOrEmpty(e.Key)
-                            && e.Key!.IsSupported())
-                .Select(e => e.Key!).ToArrayAsync().ConfigureAwait(false);
+                    .Where(e => !e.IsDirectory
+                                && !string.IsNullOrEmpty(e.Key)
+                                && e.Key!.IsSupported())
+                    .Select(e => e.Key!).ToArrayAsync().ConfigureAwait(false);
 
-            if (entries.Length is 0)
-            {
-                return null;
-            }
+                if (entries.Length is 0)
+                {
+                    return null;
+                }
 
-            SortByFileName(entries, stringComparer);
+                SortByFileName(entries, stringComparer);
 
-            LastOpenedArchive = archivePath;
-            return new ArchivePreparation(tempDirectory, entries, IsFullyExtracted: false);
+                LastOpenedArchive = archivePath;
+                return new ArchivePreparation(tempDirectory, entries, IsFullyExtracted: false);
             }
         }
         catch (Exception ex)
         {
             DebugHelper.LogDebug(nameof(ArchiveExtractionService), nameof(PrepareArchiveAsync), ex);
             return null;
+        }
+    }
+
+    /// <summary>
+    ///     Extracts a set of archive entries to the previously created <see cref="TempZipDirectory" />.
+    ///     Entries are written flat (without preserving the entry's directory structure) so the
+    ///     standard, non-recursive file listing/sorting works on the result.
+    ///     The archive is opened once and entries are extracted in order.
+    /// </summary>
+    /// <returns>List of absolute paths of successfully extracted files in the requested order.</returns>
+    public async Task<IReadOnlyList<string>> ExtractEntriesAsync(
+        string archivePath,
+        IReadOnlyList<string> entryKeys,
+        CancellationToken ct = default)
+    {
+        var tempDirectory = TempZipDirectory;
+        if (string.IsNullOrEmpty(tempDirectory) || entryKeys is null || entryKeys.Count == 0)
+        {
+            return [];
+        }
+
+        try
+        {
+            var keySet = new HashSet<string>(entryKeys, StringComparer.Ordinal);
+            var extractedMap = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            // Open archive once and extract matching entries
+            var archive = await ArchiveFactory.OpenAsyncArchive(archivePath, cancellationToken: ct).ConfigureAwait(false);
+            await using (archive.ConfigureAwait(false))
+            {
+                await foreach (var entry in archive.EntriesAsync.WithCancellation(ct).ConfigureAwait(false))
+                {
+                    if (entry.IsDirectory || string.IsNullOrEmpty(entry.Key))
+                    {
+                        continue;
+                    }
+
+                    if (!keySet.Contains(entry.Key))
+                    {
+                        continue;
+                    }
+
+                    var extractedPath = WriteEntryFlat(entry, tempDirectory);
+                    if (!string.IsNullOrEmpty(extractedPath))
+                    {
+                        extractedMap[entry.Key] = extractedPath;
+                    }
+
+                    // Stop early once all requested keys have been extracted
+                    if (extractedMap.Count == keySet.Count)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            // Return paths in the original requested order
+            var result = new List<string>(entryKeys.Count);
+            foreach (var key in entryKeys)
+            {
+                if (extractedMap.TryGetValue(key, out var path))
+                {
+                    result.Add(path);
+                }
+            }
+            return result;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            DebugHelper.LogDebug(nameof(ArchiveExtractionService), nameof(ExtractEntriesAsync), ex);
+            return [];
         }
     }
 
@@ -178,43 +213,13 @@ public class ArchiveExtractionService
         string entryKey,
         CancellationToken ct = default)
     {
-        var tempDirectory = TempZipDirectory;
-        if (string.IsNullOrEmpty(tempDirectory) || string.IsNullOrEmpty(entryKey))
+        if (string.IsNullOrEmpty(entryKey))
         {
             return null;
         }
-        try
-        {
-            var archive = await ArchiveFactory.OpenAsyncArchive(archivePath, cancellationToken: ct).ConfigureAwait(false);
-            await using (archive.ConfigureAwait(false))
-            {
-                await foreach (var entry in archive.EntriesAsync.WithCancellation(ct).ConfigureAwait(false))
-                {
-                    if (entry.IsDirectory || string.IsNullOrEmpty(entry.Key))
-                    {
-                        continue;
-                    }
 
-                    if (!string.Equals(entry.Key, entryKey, StringComparison.Ordinal))
-                    {
-                        continue;
-                    }
-
-                    return WriteEntryFlat(entry, tempDirectory);
-                }
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            DebugHelper.LogDebug(nameof(ArchiveExtractionService), nameof(ExtractEntryAsync), ex);
-            return null;
-        }
-
-        return null;
+        var results = await ExtractEntriesAsync(archivePath, [entryKey], ct).ConfigureAwait(false);
+        return results.Count > 0 ? results[0] : null;
     }
 
     /// <summary>

--- a/src/PicView.Core/ArchiveHandling/ArchiveExtractionService.cs
+++ b/src/PicView.Core/ArchiveHandling/ArchiveExtractionService.cs
@@ -68,6 +68,10 @@ public class ArchiveExtractionService
                 return null;
             }
 
+            _extractionCts?.Cancel();
+            _extractionCts?.Dispose();
+            _extractionCts = null;
+
             var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(tempDirectory);
             TempZipDirectory = tempDirectory;
@@ -352,27 +356,45 @@ public class ArchiveExtractionService
     /// </summary>
     public void Cleanup()
     {
-        Cleanup(TempZipDirectory);
+        _extractionCts?.Cancel();
+        _extractionCts?.Dispose();
+        _extractionCts = null;
+
+        var tempDirectory = TempZipDirectory;
+        if (!string.IsNullOrEmpty(tempDirectory) && Directory.Exists(tempDirectory))
+        {
+            try
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+            catch (Exception ex)
+            {
+                DebugHelper.LogDebug(nameof(ArchiveExtractionService), nameof(Cleanup), ex);
+            }
+        }
+
+        TempZipDirectory = null;
+        LastOpenedArchive = null;
     }
     
     public void Cleanup(string? tempZipDirectory)
     {
+        if (string.IsNullOrEmpty(tempZipDirectory))
+        {
+            return;
+        }
+
+        if (string.Equals(tempZipDirectory, TempZipDirectory, StringComparison.OrdinalIgnoreCase))
+        {
+            Cleanup();
+            return;
+        }
+
         try
         {
-            _extractionCts?.Cancel();
-            _extractionCts?.Dispose();
-            _extractionCts = null;
-
-            if (string.IsNullOrEmpty(tempZipDirectory) || !Directory.Exists(tempZipDirectory))
+            if (Directory.Exists(tempZipDirectory))
             {
-                return;
-            }
-
-            Directory.Delete(tempZipDirectory, true);
-            if (string.Equals(tempZipDirectory, TempZipDirectory, StringComparison.OrdinalIgnoreCase))
-            {
-                TempZipDirectory = null;
-                LastOpenedArchive = null;
+                Directory.Delete(tempZipDirectory, true);
             }
         }
         catch (Exception ex)

--- a/src/PicView.Core/Extensions/StringExtensions.cs
+++ b/src/PicView.Core/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 
 namespace PicView.Core.Extensions;
 
@@ -52,8 +52,13 @@ public static partial class StringExtensions
     /// </summary>
     /// <param name="value">The string to combine with the application name.</param>
     /// <returns>A new string containing the original string followed by " - PicView".</returns>
-    public static string CombineWithAppName(string value)
+    public static string CombineWithAppName(string? value)
     {
+        if (string.IsNullOrEmpty(value))
+        {
+            return AppName;
+        }
+
         const string separator = " - ";
         var requiredLength = value.Length + separator.Length + AppName.Length;
 

--- a/src/PicView.Core/FileHistory/FileHistoryManager.cs
+++ b/src/PicView.Core/FileHistory/FileHistoryManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using PicView.Core.Config.ConfigFileManagement;
 using PicView.Core.DebugTools;
@@ -126,7 +126,7 @@ public static class FileHistoryManager
     /// </summary>
     public static void Add(string path)
     {
-        if (!Settings.Navigation.IsFileHistoryEnabled)
+        if (!Settings.Navigation.IsFileHistoryEnabled || _entries is null)
         {
             return;
         }

--- a/src/PicView.Core/Localization/TranslationManager.cs
+++ b/src/PicView.Core/Localization/TranslationManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using PicView.Core.DebugTools;
@@ -20,7 +20,7 @@ public static class TranslationManager
     /// <summary>
     /// The current language model containing translations.
     /// </summary>
-    public static LanguageModel? Translation { get; private set; }
+    public static LanguageModel Translation { get; private set; } = new();
 
     /// <summary>
     /// Initializes the language model by setting all strings to empty.

--- a/src/PicView.Core/Navigation/FileWatcherService.cs
+++ b/src/PicView.Core/Navigation/FileWatcherService.cs
@@ -173,21 +173,22 @@ public class FileWatcherService(
         {
             return;
         }
-        var insertionIndex = FileSortOrder.InsertSorted(files, newFile, _stringComparer);
-        
-        tab.ImageIterator.UpdateNavigationProperties();
-        
-        if (tab.Model.FileInfo is null)
+        int insertionIndex;
+        lock (files)
         {
-            return;
+            insertionIndex = FileSortOrder.InsertSorted(files, newFile, _stringComparer);
         }
-        var newIndex = files.FindIndex(x =>
-            x.FullName.AsSpan().Equals(tab.Model.FileInfo.FullName.AsSpan(), StringComparison.OrdinalIgnoreCase));
-        if (newIndex >= 0)
+        
+        if (insertionIndex <= tab.ImageIterator.CurrentIndex)
         {
-            tab.ImageIterator.SetCurrentIndex(newIndex);
+            tab.ImageIterator.SetCurrentIndex(tab.ImageIterator.CurrentIndex + 1);
+        }
+        else
+        {
+            tab.ImageIterator.UpdateNavigationProperties();
         }
 
+        tab.ImageIterator.NotifyFileAdded();
         _cache.Resynchronize(tab.Id, files);
         tab.UpdateTabTitle();
 

--- a/src/PicView.Core/Navigation/ImageIterator.cs
+++ b/src/PicView.Core/Navigation/ImageIterator.cs
@@ -34,7 +34,7 @@ public class ImageIterator(IImageCache cache, IThumbnailCache thumbCache, IThumb
 
     private void UpdateNavigationProperties(int index, int count)
     {
-        if (count <= 1)
+        if (count <= 1 && !_tab.IsArchiveExtracting.Value)
         {
             _tab.CanNavigateForwards.Value = false;
             _tab.CanNavigateBackwards.Value = false;
@@ -42,13 +42,14 @@ public class ImageIterator(IImageCache cache, IThumbnailCache thumbCache, IThumb
         else
         {
             var isLooping = Settings.UIProperties.Looping;
+            var isExtracting = _tab.IsArchiveExtracting.Value;
             if (Settings.ImageScaling.ShowImageSideBySide)
             {
-                _tab.CanNavigateForwards.Value = isLooping || index < count - 2;
+                _tab.CanNavigateForwards.Value = isLooping || isExtracting || index < count - 2;
             }
             else
             {
-                _tab.CanNavigateForwards.Value = isLooping || index < count - 1;
+                _tab.CanNavigateForwards.Value = isLooping || isExtracting || index < count - 1;
             }
 
             _tab.CanNavigateBackwards.Value = isLooping || index > 0;
@@ -67,7 +68,17 @@ public class ImageIterator(IImageCache cache, IThumbnailCache thumbCache, IThumb
         }
         else
         {
-            var (iteration, isReversed) = IterationHelper.GetIteration(CurrentIndex, Files.Count, navigateTo, skipAmount);
+            int iteration;
+            bool isReversed;
+            if (navigateTo == NavigateTo.Next && CurrentIndex == Files.Count - 1 && _tab.IsArchiveExtracting.Value)
+            {
+                iteration = CurrentIndex + 1;
+                isReversed = false;
+            }
+            else
+            {
+                (iteration, isReversed) = IterationHelper.GetIteration(CurrentIndex, Files.Count, navigateTo, skipAmount);
+            }
             IsReversed = isReversed;
             await IterateToIndexAsync(iteration, ct).ConfigureAwait(false);
         }
@@ -75,11 +86,28 @@ public class ImageIterator(IImageCache cache, IThumbnailCache thumbCache, IThumb
 
     public async ValueTask IterateToIndexAsync(int index, CancellationTokenSource ct)
     {
-        if (index < 0 || index >= Files.Count)
+        if (index < 0)
         {
             return;
         }
-        
+
+        if (index >= Files.Count)
+        {
+            if (_tab.IsArchiveExtracting.Value)
+            {
+                _tab.SetLoading();
+                var fileAppeared = await WaitForFileIndexAsync(index, ct.Token).ConfigureAwait(false);
+                if (!fileAppeared || index >= Files.Count)
+                {
+                    UpdateNavigationProperties();
+                    return;
+                }
+            }
+            else
+            {
+                return;
+            }
+        }
         
         // Handle internal TIFF navigation
         if (_tab.Model?.TiffNavigation is not null && ShouldNavigateTiffEntry(_tab.Model, IsReversed))
@@ -106,7 +134,7 @@ public class ImageIterator(IImageCache cache, IThumbnailCache thumbCache, IThumb
                     var thumb = !_thumbCache.IsEmpty && _thumbCache.TryGet(targetFile.FullName, out var cachedThumb)
                         ? cachedThumb
                         : _thumbnailLoader.GetThumbQuick(targetFile);
-                    if (index != CurrentIndex)
+                    if (!IsTargetActive(targetFile, index))
                     {
                         return;
                     }
@@ -116,7 +144,7 @@ public class ImageIterator(IImageCache cache, IThumbnailCache thumbCache, IThumb
                     var successfullyLoaded = await Cache
                         .WaitForLoadingCompleteAsync(_tab.Id, index, _tab.ImageIterator.Files, ct.Token)
                         .ConfigureAwait(false);
-                    if (successfullyLoaded && index == CurrentIndex)
+                    if (successfullyLoaded && IsTargetActive(targetFile, index))
                     {
                         if (preLoadValue.ImageModel.Image is null)
                         {
@@ -141,7 +169,7 @@ public class ImageIterator(IImageCache cache, IThumbnailCache thumbCache, IThumb
         async Task AttemptManualLoad()
         {
             var manuallyLoaded = await Cache.LoadAsync(_tab.Id, index, Files, ct.Token).ConfigureAwait(false);
-            if (index == CurrentIndex && manuallyLoaded is not null)
+            if (IsTargetActive(targetFile, index) && manuallyLoaded is not null)
             {
                 UpdateModel(manuallyLoaded);
             }
@@ -396,7 +424,17 @@ public class ImageIterator(IImageCache cache, IThumbnailCache thumbCache, IThumb
 
         _lastRepeatTime = now;
 
-        var (iteration, isReversed) = IterationHelper.GetIteration(CurrentIndex, Files.Count, to, SkipAmount.One);
+        int iteration;
+        bool isReversed;
+        if (to == NavigateTo.Next && CurrentIndex == Files.Count - 1 && _tab.IsArchiveExtracting.Value)
+        {
+            iteration = CurrentIndex + 1;
+            isReversed = false;
+        }
+        else
+        {
+            (iteration, isReversed) = IterationHelper.GetIteration(CurrentIndex, Files.Count, to, SkipAmount.One);
+        }
         IsReversed = isReversed;
         await IterateToIndexAsync(iteration, ct).ConfigureAwait(false);
     }
@@ -405,6 +443,60 @@ public class ImageIterator(IImageCache cache, IThumbnailCache thumbCache, IThumb
     {
         // Reset the throttle so the next click reacts instantly.
         _lastRepeatTime = DateTime.MinValue; 
+    }
+
+    private readonly object _fileWaitLock = new();
+    private TaskCompletionSource<bool>? _fileAddedTcs;
+
+    public void NotifyFileAdded()
+    {
+        lock (_fileWaitLock)
+        {
+            _fileAddedTcs?.TrySetResult(true);
+        }
+    }
+
+    private async Task<bool> WaitForFileIndexAsync(int targetIndex, CancellationToken ct)
+    {
+        while (targetIndex >= Files.Count && _tab.IsArchiveExtracting.Value && !ct.IsCancellationRequested)
+        {
+            TaskCompletionSource<bool> tcs;
+            lock (_fileWaitLock)
+            {
+                _fileAddedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                tcs = _fileAddedTcs;
+            }
+
+            using var reg = ct.Register(() => tcs.TrySetCanceled(ct));
+
+            try
+            {
+                var completedTask = await Task.WhenAny(tcs.Task, Task.Delay(3000, ct)).ConfigureAwait(false);
+                if (completedTask != tcs.Task)
+                {
+                    break;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+        }
+
+        return targetIndex < Files.Count;
+    }
+
+    private bool IsTargetActive(FileInfo targetFile, int targetIndex)
+    {
+        if (CurrentIndex == targetIndex)
+        {
+            return true;
+        }
+        if (CurrentIndex >= 0 && CurrentIndex < Files.Count)
+        {
+            return string.Equals(Files[CurrentIndex].FullName, targetFile.FullName, StringComparison.OrdinalIgnoreCase);
+        }
+        return false;
     }
 
     #endregion

--- a/src/PicView.Core/Navigation/ImageIterator.cs
+++ b/src/PicView.Core/Navigation/ImageIterator.cs
@@ -70,7 +70,7 @@ public class ImageIterator(IImageCache cache, IThumbnailCache thumbCache, IThumb
         {
             int iteration;
             bool isReversed;
-            if (navigateTo == NavigateTo.Next && CurrentIndex == Files.Count - 1 && _tab.IsArchiveExtracting.Value)
+            if (navigateTo == NavigateTo.Next && CurrentIndex >= Files.Count - 1 && _tab.IsArchiveExtracting.Value)
             {
                 iteration = CurrentIndex + 1;
                 isReversed = false;
@@ -426,7 +426,7 @@ public class ImageIterator(IImageCache cache, IThumbnailCache thumbCache, IThumb
 
         int iteration;
         bool isReversed;
-        if (to == NavigateTo.Next && CurrentIndex == Files.Count - 1 && _tab.IsArchiveExtracting.Value)
+        if (to == NavigateTo.Next && CurrentIndex >= Files.Count - 1 && _tab.IsArchiveExtracting.Value)
         {
             iteration = CurrentIndex + 1;
             isReversed = false;

--- a/src/PicView.Core/Navigation/Interfaces/IImageIterator.cs
+++ b/src/PicView.Core/Navigation/Interfaces/IImageIterator.cs
@@ -79,4 +79,9 @@ public interface IImageIterator : IDisposable
     /// Updates the forward/backward navigation permissions based on the current index and list bounds.
     /// </summary>
     void UpdateNavigationProperties();
+
+    /// <summary>
+    /// Notifies the iterator that a new file has been added to the file list.
+    /// </summary>
+    void NotifyFileAdded();
 }

--- a/src/PicView.Core/Navigation/NavigationService.cs
+++ b/src/PicView.Core/Navigation/NavigationService.cs
@@ -314,12 +314,48 @@ public class NavigationService(
 
             FileHistoryManager.Add(archivePath);
 
-            // Kick off background extraction of remaining entries. FileWatcherService picks them up.
+            // Kick off background extraction of remaining entries in batches of 10. FileWatcherService picks them up.
             if (prep.EntryKeys.Length > initialKeys.Length)
             {
+                var totalCount = prep.EntryKeys.Length;
+                var initialExtractedCount = extractedPaths.Count;
                 var remainingKeys = prep.EntryKeys.Skip(initialKeys.Length).ToArray();
-                var backgroundToken = tab.GetTabCancellation().Token;
-                _ = Task.Run(() => tab.ArchiveExtractionService.ExtractRemainingAsync(archivePath, remainingKeys, backgroundToken), backgroundToken);
+                var backgroundToken = tab.ArchiveExtractionService.ResetExtractionCts();
+
+                tab.IsArchiveExtracting.Value = true;
+                tab.ArchiveExtractionProgressText.Value = $"{initialExtractedCount}/{totalCount}";
+
+                var progress = new Progress<int>(current =>
+                {
+                    tab.ArchiveExtractionProgressText.Value = $"{current}/{totalCount}";
+                });
+
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await tab.ArchiveExtractionService.ExtractRemainingAsync(
+                            archivePath,
+                            remainingKeys,
+                            initialCount: initialExtractedCount,
+                            totalCount: totalCount,
+                            progress: progress,
+                            batchSize: 10,
+                            ct: backgroundToken).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        tab.IsArchiveExtracting.Value = false;
+                        tab.ArchiveExtractionProgressText.Value = null;
+                        tab.ImageIterator?.NotifyFileAdded();
+                        tab.ImageIterator?.UpdateNavigationProperties();
+                    }
+                }, backgroundToken);
+            }
+            else
+            {
+                tab.IsArchiveExtracting.Value = false;
+                tab.ArchiveExtractionProgressText.Value = null;
             }
 
             tab.ArchiveExtractionService.Cleanup(tempZipDir);

--- a/src/PicView.Core/Navigation/NavigationService.cs
+++ b/src/PicView.Core/Navigation/NavigationService.cs
@@ -297,8 +297,74 @@ public class NavigationService(
                 return true;
             }
 
-            // Staged extraction: extract up to the first 10 entries immediately and navigate to them,
-            // then extract the rest in the background while FileWatcherService inserts each new file into the iterator.
+            if (!Settings.Navigation.AlwaysUncompressEntireArchive)
+            {
+                // Staged extraction: extract the first entry (or 2 if side-by-side), navigate to it, then extract the rest in
+                // the background one by one while FileWatcherService inserts each new file into the iterator.
+                var firstKey = prep.EntryKeys[0];
+                var firstPath = await tab.ArchiveExtractionService.ExtractEntryAsync(archivePath, firstKey, ct.Token).ConfigureAwait(false);
+
+                if (string.IsNullOrEmpty(firstPath) || ct.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                if (Settings.ImageScaling.ShowImageSideBySide && prep.EntryKeys.Length > 1)
+                {
+                    var secondKey = prep.EntryKeys[1];
+                    var secondPath = await tab.ArchiveExtractionService.ExtractEntryAsync(archivePath, secondKey, ct.Token).ConfigureAwait(false);
+                    var seedFiles = new List<FileInfo>
+                    {
+                        new(firstPath),
+                        new(secondPath)
+                    };
+                    await RepopulateIterator(seedFiles[0], tab, ct, seedFiles).ConfigureAwait(false);
+                }
+                else
+                {
+                    var seedFiles = new List<FileInfo> { new(firstPath) };
+                    await RepopulateIterator(seedFiles[0], tab, ct, seedFiles).ConfigureAwait(false);
+                }
+
+                FileHistoryManager.Add(archivePath);
+
+                // Kick off background extraction of remaining entries one by one without batching or progress indicator.
+                var initialCount = Settings.ImageScaling.ShowImageSideBySide && prep.EntryKeys.Length > 1 ? 2 : 1;
+                if (prep.EntryKeys.Length > initialCount)
+                {
+                    var remainingKeys = prep.EntryKeys.Skip(initialCount).ToArray();
+                    var backgroundToken = tab.ArchiveExtractionService.ResetExtractionCts();
+                    tab.IsArchiveExtracting.Value = true;
+                    tab.ArchiveExtractionProgressText.Value = null;
+                    tab.ImageIterator?.UpdateNavigationProperties();
+
+                    _ = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await tab.ArchiveExtractionService.ExtractRemainingAsync(archivePath, remainingKeys, ct: backgroundToken).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            tab.IsArchiveExtracting.Value = false;
+                            tab.ArchiveExtractionProgressText.Value = null;
+                            tab.ImageIterator?.NotifyFileAdded();
+                            tab.ImageIterator?.UpdateNavigationProperties();
+                        }
+                    }, backgroundToken);
+                }
+                else
+                {
+                    tab.IsArchiveExtracting.Value = false;
+                    tab.ArchiveExtractionProgressText.Value = null;
+                }
+
+                tab.ArchiveExtractionService.Cleanup(tempZipDir);
+                return true;
+            }
+
+            // Staged extraction (AlwaysUncompressEntireArchive = true): extract up to the first 10 entries immediately and navigate to them,
+            // then extract the rest in batches of 10 in the background while reporting progress with the bottom-right indicator.
             const int initialExtractCount = 10;
             var initialKeys = prep.EntryKeys.Take(initialExtractCount).ToArray();
             var extractedPaths = await tab.ArchiveExtractionService.ExtractEntriesAsync(archivePath, initialKeys, ct.Token).ConfigureAwait(false);
@@ -309,8 +375,8 @@ public class NavigationService(
             }
 
             // Seed iterator with initial extracted pages for immediate viewing and preloading
-            var seedFiles = extractedPaths.Select(p => new FileInfo(p)).ToList();
-            await RepopulateIterator(seedFiles[0], tab, ct, seedFiles).ConfigureAwait(false);
+            var seedFilesList = extractedPaths.Select(p => new FileInfo(p)).ToList();
+            await RepopulateIterator(seedFilesList[0], tab, ct, seedFilesList).ConfigureAwait(false);
 
             FileHistoryManager.Add(archivePath);
 

--- a/src/PicView.Core/Navigation/NavigationService.cs
+++ b/src/PicView.Core/Navigation/NavigationService.cs
@@ -251,86 +251,97 @@ public class NavigationService(
         }
 
         tab.SetLoading();
+        // Show progress spinner while extracting archive
+        if (tab.ParentWindowContext is not null)
+        {
+            tab.ParentWindowContext.IsLoadingIndicatorShown.Value = true;
+        }
         
         // Retrieve the temporary directory for the possible previous archive extraction
         var tempZipDir = tab.ArchiveExtractionService.TempZipDirectory;
 
-        var preparation = await tab.ArchiveExtractionService.PrepareArchiveAsync(
-            archivePath,
-            platformService.ExtractWithLocalSoftwareAsync,
-            stringComparer).ConfigureAwait(false);
-
-        if (preparation is null || string.IsNullOrEmpty(tab.ArchiveExtractionService.TempZipDirectory))
+        try
         {
-            return false;
-        }
+            var preparation = await tab.ArchiveExtractionService.PrepareArchiveAsync(
+                archivePath,
+                platformService.ExtractWithLocalSoftwareAsync,
+                stringComparer).ConfigureAwait(false);
 
-        if (ct.IsCancellationRequested)
-        {
-            return false;
-        }
-
-        var prep = preparation.Value;
-
-        if (prep.IsFullyExtracted)
-        {
-            // Local-software extractor already wrote every file to disk; build the file list
-            // from the already-extracted paths so we don't depend on FileListRetriever's
-            // recursion settings.
-            var allFiles = prep.EntryKeys.Select(p => new FileInfo(p)).ToList();
-            if (allFiles.Count is 0)
+            if (preparation is null || string.IsNullOrEmpty(tab.ArchiveExtractionService.TempZipDirectory))
             {
                 return false;
             }
 
-            await RepopulateIterator(allFiles[0], tab, ct, allFiles).ConfigureAwait(false);
+            if (ct.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            var prep = preparation.Value;
+
+            if (prep.IsFullyExtracted)
+            {
+                // Local-software extractor already wrote every file to disk; build the file list
+                // from the already-extracted paths so we don't depend on FileListRetriever's
+                // recursion settings.
+                var allFiles = prep.EntryKeys.Select(p => new FileInfo(p)).ToList();
+                if (allFiles.Count is 0)
+                {
+                    return false;
+                }
+
+                await RepopulateIterator(allFiles[0], tab, ct, allFiles).ConfigureAwait(false);
+
+                FileHistoryManager.Add(archivePath);
+                tab.ArchiveExtractionService.Cleanup(tempZipDir);
+                return true;
+            }
+
+            // Staged extraction: extract up to the first 10 entries immediately and navigate to them,
+            // then extract the rest in the background while FileWatcherService inserts each new file into the iterator.
+            const int initialExtractCount = 10;
+            var initialKeys = prep.EntryKeys.Take(initialExtractCount).ToArray();
+            var extractedPaths = await tab.ArchiveExtractionService.ExtractEntriesAsync(archivePath, initialKeys, ct.Token).ConfigureAwait(false);
+
+            if (extractedPaths.Count == 0 || ct.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            // Seed iterator with initial extracted pages for immediate viewing and preloading
+            var seedFiles = extractedPaths.Select(p => new FileInfo(p)).ToList();
+            await RepopulateIterator(seedFiles[0], tab, ct, seedFiles).ConfigureAwait(false);
 
             FileHistoryManager.Add(archivePath);
+
+            // Kick off background extraction of remaining entries. FileWatcherService picks them up.
+            if (prep.EntryKeys.Length > initialKeys.Length)
+            {
+                var remainingKeys = prep.EntryKeys.Skip(initialKeys.Length).ToArray();
+                var backgroundToken = tab.GetTabCancellation().Token;
+                _ = Task.Run(() => tab.ArchiveExtractionService.ExtractRemainingAsync(archivePath, remainingKeys, backgroundToken), backgroundToken);
+            }
+
             tab.ArchiveExtractionService.Cleanup(tempZipDir);
             return true;
         }
-
-        // Staged extraction: extract the first entry, navigate to it, then extract the rest in
-        // the background while FileWatcherService inserts each new file into the iterator.
-        var firstKey = prep.EntryKeys[0];
-        var firstPath = await tab.ArchiveExtractionService.ExtractEntryAsync(archivePath, firstKey, ct.Token).ConfigureAwait(false);
-
-        if (string.IsNullOrEmpty(firstPath) || ct.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
             return false;
         }
-
-        if (Settings.ImageScaling.ShowImageSideBySide && prep.EntryKeys.Length > 1)
+        catch (Exception ex)
         {
-            var secondKey = prep.EntryKeys[1];
-            var secondPath = await tab.ArchiveExtractionService.ExtractEntryAsync(archivePath, secondKey, ct.Token).ConfigureAwait(false);
-            var seedFiles = new List<FileInfo>
+            DebugHelper.LogDebug(nameof(NavigationService), nameof(LoadFromArchiveAsync), ex);
+            return false;
+        }
+        finally
+        {
+            // Hide progress spinner when initial extraction and display complete
+            if (tab.ParentWindowContext is not null)
             {
-                new(firstPath),
-                new(secondPath)
-            };
-            await RepopulateIterator(seedFiles[0], tab, ct, seedFiles).ConfigureAwait(false);
+                tab.ParentWindowContext.IsLoadingIndicatorShown.Value = false;
+            }
         }
-        else
-        {
-            // Seed the iterator with just the first extracted file. Watching the temp directory
-            // first ensures every subsequent file creation event is captured by FileWatcherService
-            // and inserted in sorted order into the iterator/gallery.
-            var seedFiles = new List<FileInfo> { new(firstPath) };
-            await RepopulateIterator(seedFiles[0], tab, ct, seedFiles).ConfigureAwait(false);
-        }
-
-
-        // Kick off background extraction of remaining entries. FileWatcherService picks them up.
-        if (prep.EntryKeys.Length > 1)
-        {
-            var remainingKeys = prep.EntryKeys.Skip(1).ToArray();
-            var backgroundToken = tab.GetTabCancellation().Token;
-            _ = Task.Run(() => tab.ArchiveExtractionService.ExtractRemainingAsync(archivePath, remainingKeys, backgroundToken), backgroundToken);
-        }
-
-        tab.ArchiveExtractionService.Cleanup(tempZipDir);
-        return true;
     }
 
     public async ValueTask LoadFromUrlAsync(string url, TabViewModel tab, CancellationTokenSource ct)

--- a/src/PicView.Core/Navigation/SharedImageCache.cs
+++ b/src/PicView.Core/Navigation/SharedImageCache.cs
@@ -108,13 +108,33 @@ public class SharedImageCache : IImageCache
         {
             currentItems.Add(oldItems.Current);
         }
-        dict.Clear();
-
         var newFileMap = new Dictionary<string, int>(_pathLookup.Comparer);
         for (var i = 0; i < files.Count; i++)
         {
             newFileMap[files[i].FullName] = i;
         }
+
+        // Fast-path: if no existing cached item's index shifted and none were removed, avoid clearing the cache
+        var anyIndexChanged = false;
+        foreach (var item in currentItems)
+        {
+            if (!newFileMap.TryGetValue(item.Value.ImageModel.FileInfo.FullName, out var newIndex) || newIndex != item.Key)
+            {
+                anyIndexChanged = true;
+                break;
+            }
+        }
+
+        if (!anyIndexChanged)
+        {
+            if (files.Count > 0 && _ownerContexts.TryGetValue(ownerId, out var existingCtx))
+            {
+                _ownerContexts[ownerId] = (files[0].DirectoryName ?? string.Empty, files, existingCtx.CurrentIndex);
+            }
+            return;
+        }
+
+        dict.Clear();
 
         foreach (var item in currentItems)
         {

--- a/src/PicView.Core/Titles/ImageTitleFormatter.cs
+++ b/src/PicView.Core/Titles/ImageTitleFormatter.cs
@@ -44,7 +44,7 @@ public static class ImageTitleFormatter
         sb.Append(info.Height);
         sb.Append(AspectRatioFormatter.FormatAspectRatio(info.Width, info.Height));
         sb.Append(") "); 
-        if (info.FileInfo is not null)
+        if (info.FileInfo is not null && info.FileInfo.Exists)
         {
             sb.Append(info.FileInfo.Length.GetReadableFileSize());
         }

--- a/src/PicView.Core/ViewModels/TabViewModel.cs
+++ b/src/PicView.Core/ViewModels/TabViewModel.cs
@@ -88,6 +88,8 @@ public class TabViewModel(Action<TabViewModel> closeTab, MainWindowViewModel par
     /// <inheritdoc cref="Core.Navigation.Interfaces.IImageIterator"/>>
     public IImageIterator? ImageIterator { get; private set; }
     public ArchiveExtractionService? ArchiveExtractionService { get; } = new();
+    public BindableReactiveProperty<bool> IsArchiveExtracting { get; } = new(false);
+    public BindableReactiveProperty<string?> ArchiveExtractionProgressText { get; } = new(null);
     public IThumbnailCache? ThumbnailCache { get; private set; }
 
     private IFileWatcherService? _fileWatcherService = fileWatcherService;

--- a/src/PicView.Tests/ArchiveHandling/ArchiveExtractionServiceTests.cs
+++ b/src/PicView.Tests/ArchiveHandling/ArchiveExtractionServiceTests.cs
@@ -82,7 +82,7 @@ public class ArchiveExtractionServiceTests
     }
 
     [Fact]
-    public async Task PrepareArchiveAsync_AlwaysUncompressEntireArchive_ExtractsAllFilesAndReturnsFullyExtracted()
+    public async Task PrepareArchiveAsync_AlwaysUncompressEntireArchive_ReturnsEntryKeysForStagedExtraction()
     {
         var tempZipPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.zip");
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -92,37 +92,29 @@ public class ArchiveExtractionServiceTests
         {
             var file1 = Path.Combine(tempDir, "test1.jpg");
             var file2 = Path.Combine(tempDir, "test2.png");
-            File.WriteAllBytes(file1, new byte[] { 0xFF, 0xD8, 0xFF });
-            File.WriteAllBytes(file2, new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+            File.WriteAllBytes(file1, [0xFF, 0xD8, 0xFF]);
+            File.WriteAllBytes(file2, [0x89, 0x50, 0x4E, 0x47]);
 
             System.IO.Compression.ZipFile.CreateFromDirectory(tempDir, tempZipPath);
 
             var service = new ArchiveExtractionService();
 
-            // Test default (false)
-            Settings.Navigation.AlwaysUncompressEntireArchive = false;
-            var resultFalse = await service.PrepareArchiveAsync(
-                tempZipPath,
-                (_, _) => Task.FromResult(false),
-                string.Compare);
-
-            Assert.NotNull(resultFalse);
-            Assert.False(resultFalse.Value.IsFullyExtracted);
-            Assert.Equal(2, resultFalse.Value.EntryKeys.Length);
-            service.Cleanup();
-
-            // Test AlwaysUncompressEntireArchive = true
             Settings.Navigation.AlwaysUncompressEntireArchive = true;
-            var resultTrue = await service.PrepareArchiveAsync(
+            var result = await service.PrepareArchiveAsync(
                 tempZipPath,
                 (_, _) => Task.FromResult(false),
                 string.Compare);
 
-            Assert.NotNull(resultTrue);
-            Assert.True(resultTrue.Value.IsFullyExtracted);
-            Assert.Equal(2, resultTrue.Value.EntryKeys.Length);
-            Assert.True(File.Exists(resultTrue.Value.EntryKeys[0]));
-            Assert.True(File.Exists(resultTrue.Value.EntryKeys[1]));
+            Assert.NotNull(result);
+            Assert.False(result.Value.IsFullyExtracted);
+            Assert.Equal(2, result.Value.EntryKeys.Length);
+
+            // Test extracting initial entries
+            var extracted = await service.ExtractEntriesAsync(tempZipPath, result.Value.EntryKeys);
+            Assert.Equal(2, extracted.Count);
+            Assert.True(File.Exists(extracted[0]));
+            Assert.True(File.Exists(extracted[1]));
+
             service.Cleanup();
         }
         finally
@@ -145,25 +137,22 @@ public class ArchiveExtractionServiceTests
 
         try
         {
-            File.WriteAllBytes(Path.Combine(tempDir1, "a.jpg"), new byte[] { 0xFF, 0xD8, 0xFF });
-            File.WriteAllBytes(Path.Combine(tempDir2, "b.png"), new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+            File.WriteAllBytes(Path.Combine(tempDir1, "a.jpg"), [0xFF, 0xD8, 0xFF]);
+            File.WriteAllBytes(Path.Combine(tempDir2, "b.png"), [0x89, 0x50, 0x4E, 0x47]);
 
             System.IO.Compression.ZipFile.CreateFromDirectory(tempDir1, tempZipPath1);
             System.IO.Compression.ZipFile.CreateFromDirectory(tempDir2, tempZipPath2);
 
-            Settings.Navigation.AlwaysUncompressEntireArchive = true;
             var service = new ArchiveExtractionService();
 
             // First archive
             var res1 = await service.PrepareArchiveAsync(tempZipPath1, (_, _) => Task.FromResult(false), string.Compare);
             Assert.NotNull(res1);
-            Assert.True(res1.Value.IsFullyExtracted);
             var firstTempDir = service.TempZipDirectory;
 
             // Second archive
             var res2 = await service.PrepareArchiveAsync(tempZipPath2, (_, _) => Task.FromResult(false), string.Compare);
             Assert.NotNull(res2);
-            Assert.True(res2.Value.IsFullyExtracted);
 
             // Cleanup previous temp dir
             service.Cleanup(firstTempDir);
@@ -173,11 +162,130 @@ public class ArchiveExtractionServiceTests
         }
         finally
         {
-            Settings.Navigation.AlwaysUncompressEntireArchive = false;
             if (File.Exists(tempZipPath1)) File.Delete(tempZipPath1);
             if (File.Exists(tempZipPath2)) File.Delete(tempZipPath2);
             if (Directory.Exists(tempDir1)) Directory.Delete(tempDir1, true);
             if (Directory.Exists(tempDir2)) Directory.Delete(tempDir2, true);
+        }
+    }
+
+    #endregion
+
+    #region ExtractEntriesAsync
+
+    [Fact]
+    public async Task ExtractEntriesAsync_NoTempDirectory_ReturnsEmpty()
+    {
+        var service = new ArchiveExtractionService();
+
+        var result = await service.ExtractEntriesAsync("archive.zip", ["entry.jpg"]);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ExtractEntriesAsync_EmptyEntryKeys_ReturnsEmpty()
+    {
+        var service = new ArchiveExtractionService();
+
+        var result = await service.ExtractEntriesAsync("archive.zip", []);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ExtractEntriesAsync_ExtractsFirst10Pages_AndRemainingExtractsRest()
+    {
+        var tempZipPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.zip");
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            for (var i = 1; i <= 14; i++)
+            {
+                File.WriteAllBytes(Path.Combine(tempDir, $"page_{i:D2}.jpg"), [0xFF, 0xD8, 0xFF]);
+            }
+
+            System.IO.Compression.ZipFile.CreateFromDirectory(tempDir, tempZipPath);
+
+            var service = new ArchiveExtractionService();
+            var prep = await service.PrepareArchiveAsync(tempZipPath, (_, _) => Task.FromResult(false), string.Compare);
+
+            Assert.NotNull(prep);
+            Assert.Equal(14, prep.Value.EntryKeys.Length);
+
+            // Extract initial 10 pages
+            var initialKeys = prep.Value.EntryKeys.Take(10).ToArray();
+            var initialPaths = await service.ExtractEntriesAsync(tempZipPath, initialKeys);
+
+            Assert.Equal(10, initialPaths.Count);
+            foreach (var path in initialPaths)
+            {
+                Assert.True(File.Exists(path));
+            }
+
+            // Extract remaining 4 pages
+            var remainingKeys = prep.Value.EntryKeys.Skip(10).ToArray();
+            await service.ExtractRemainingAsync(tempZipPath, remainingKeys);
+
+            foreach (var key in remainingKeys)
+            {
+                var expectedPath = Path.Combine(service.TempZipDirectory!, key);
+                Assert.True(File.Exists(expectedPath));
+            }
+
+            service.Cleanup();
+        }
+        finally
+        {
+            if (File.Exists(tempZipPath)) File.Delete(tempZipPath);
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task ExtractEntriesAsync_LessThan10Pages_ExtractsAll()
+    {
+        var tempZipPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.zip");
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            for (var i = 1; i <= 5; i++)
+            {
+                File.WriteAllBytes(Path.Combine(tempDir, $"page_{i:D2}.jpg"), [0xFF, 0xD8, 0xFF]);
+            }
+
+            System.IO.Compression.ZipFile.CreateFromDirectory(tempDir, tempZipPath);
+
+            var service = new ArchiveExtractionService();
+            var prep = await service.PrepareArchiveAsync(tempZipPath, (_, _) => Task.FromResult(false), string.Compare);
+
+            Assert.NotNull(prep);
+            Assert.Equal(5, prep.Value.EntryKeys.Length);
+
+            // Extract initial pages (up to 10)
+            var initialKeys = prep.Value.EntryKeys.Take(10).ToArray();
+            var initialPaths = await service.ExtractEntriesAsync(tempZipPath, initialKeys);
+
+            Assert.Equal(5, initialPaths.Count);
+            foreach (var path in initialPaths)
+            {
+                Assert.True(File.Exists(path));
+            }
+
+            // Remaining is empty
+            var remainingKeys = prep.Value.EntryKeys.Skip(10).ToArray();
+            Assert.Empty(remainingKeys);
+
+            service.Cleanup();
+        }
+        finally
+        {
+            if (File.Exists(tempZipPath)) File.Delete(tempZipPath);
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
         }
     }
 
@@ -226,7 +334,7 @@ public class ArchiveExtractionServiceTests
         var service = new ArchiveExtractionService();
 
         // Should be a no-op when TempZipDirectory is null
-        await service.ExtractRemainingAsync("archive.zip", new[] { "entry1.jpg", "entry2.jpg" });
+        await service.ExtractRemainingAsync("archive.zip", ["entry1.jpg", "entry2.jpg"]);
     }
 
     [Fact]
@@ -235,7 +343,7 @@ public class ArchiveExtractionServiceTests
         var service = new ArchiveExtractionService();
 
         // Should be a no-op when remaining keys is empty, even if TempZipDirectory were set
-        await service.ExtractRemainingAsync("archive.zip", Array.Empty<string>());
+        await service.ExtractRemainingAsync("archive.zip", []);
     }
 
     #endregion

--- a/src/PicView.Tests/ArchiveHandling/ArchiveExtractionServiceTests.cs
+++ b/src/PicView.Tests/ArchiveHandling/ArchiveExtractionServiceTests.cs
@@ -569,5 +569,32 @@ public class ArchiveExtractionServiceTests
         Assert.False(token2.IsCancellationRequested);
     }
 
+    [Fact]
+    public void Cleanup_PreviousTempDir_DoesNotCancelCurrentExtractionToken()
+    {
+        var service = new ArchiveExtractionService();
+        var token = service.ResetExtractionCts();
+
+        var previousDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(previousDir);
+
+        try
+        {
+            service.Cleanup(previousDir);
+
+            // Token for current extraction should NOT be cancelled
+            Assert.False(token.IsCancellationRequested);
+            Assert.False(Directory.Exists(previousDir));
+        }
+        finally
+        {
+            if (Directory.Exists(previousDir))
+            {
+                Directory.Delete(previousDir, true);
+            }
+            service.Cleanup();
+        }
+    }
+
     #endregion
 }

--- a/src/PicView.Tests/ArchiveHandling/ArchiveExtractionServiceTests.cs
+++ b/src/PicView.Tests/ArchiveHandling/ArchiveExtractionServiceTests.cs
@@ -225,15 +225,74 @@ public class ArchiveExtractionServiceTests
                 Assert.True(File.Exists(path));
             }
 
-            // Extract remaining 4 pages
+            // Extract remaining 4 pages with progress tracking
+            var progressReports = new List<int>();
+            var progress = new Progress<int>(progressReports.Add);
             var remainingKeys = prep.Value.EntryKeys.Skip(10).ToArray();
-            await service.ExtractRemainingAsync(tempZipPath, remainingKeys);
+            await service.ExtractRemainingAsync(
+                tempZipPath,
+                remainingKeys,
+                initialCount: 10,
+                totalCount: 14,
+                progress: progress,
+                batchSize: 10);
 
             foreach (var key in remainingKeys)
             {
                 var expectedPath = Path.Combine(service.TempZipDirectory!, key);
                 Assert.True(File.Exists(expectedPath));
             }
+
+            // Progress should report the final count
+            Assert.Contains(14, progressReports);
+
+            service.Cleanup();
+        }
+        finally
+        {
+            if (File.Exists(tempZipPath)) File.Delete(tempZipPath);
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task ExtractRemainingAsync_MultipleBatches_ReportsProgressAtEachBatch()
+    {
+        var tempZipPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.zip");
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            for (var i = 1; i <= 25; i++)
+            {
+                File.WriteAllBytes(Path.Combine(tempDir, $"page_{i:D2}.jpg"), [0xFF, 0xD8, 0xFF]);
+            }
+
+            System.IO.Compression.ZipFile.CreateFromDirectory(tempDir, tempZipPath);
+
+            var service = new ArchiveExtractionService();
+            var prep = await service.PrepareArchiveAsync(tempZipPath, (_, _) => Task.FromResult(false), string.Compare);
+            Assert.NotNull(prep);
+
+            var initialKeys = prep.Value.EntryKeys.Take(10).ToArray();
+            await service.ExtractEntriesAsync(tempZipPath, initialKeys);
+
+            var progressReports = new List<int>();
+            var progress = new Progress<int>(progressReports.Add);
+            var remainingKeys = prep.Value.EntryKeys.Skip(10).ToArray();
+
+            await service.ExtractRemainingAsync(
+                tempZipPath,
+                remainingKeys,
+                initialCount: 10,
+                totalCount: 25,
+                progress: progress,
+                batchSize: 10);
+
+            // Progress should have reported after first batch of 10 (20) and upon completion (25)
+            Assert.Contains(20, progressReports);
+            Assert.Contains(25, progressReports);
 
             service.Cleanup();
         }
@@ -483,6 +542,31 @@ public class ArchiveExtractionServiceTests
         // Dispose should not throw
         var exception = Record.Exception(() => tab.Dispose());
         Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ResetExtractionCts_ReturnsActiveToken_AndCancelsOnCleanup()
+    {
+        var service = new ArchiveExtractionService();
+        var token = service.ResetExtractionCts();
+
+        Assert.False(token.IsCancellationRequested);
+
+        service.Cleanup();
+
+        Assert.True(token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void ResetExtractionCts_CancelsPreviousToken()
+    {
+        var service = new ArchiveExtractionService();
+        var token1 = service.ResetExtractionCts();
+        Assert.False(token1.IsCancellationRequested);
+
+        var token2 = service.ResetExtractionCts();
+        Assert.True(token1.IsCancellationRequested);
+        Assert.False(token2.IsCancellationRequested);
     }
 
     #endregion

--- a/src/PicView.Tests/Exif/ExifFunctionsTests.cs
+++ b/src/PicView.Tests/Exif/ExifFunctionsTests.cs
@@ -6,6 +6,7 @@ using PicView.Core.Exif;
 
 namespace PicView.Tests.Exif;
 
+[Collection("Sequential")]
 public class ExifFunctionsTests : IDisposable
 {
     private readonly string _directory =

--- a/src/PicView.Tests/FileTests/AvaloniaHeadlessFilePickingTests.cs
+++ b/src/PicView.Tests/FileTests/AvaloniaHeadlessFilePickingTests.cs
@@ -1,79 +1,42 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Headless;
-using Avalonia.Threading;
-using PicView.Avalonia;
 using PicView.Avalonia.FileSystem;
 using PicView.Core.Localization;
 
 namespace PicView.Tests.FileTests;
 
+[Collection("Sequential")]
 public class AvaloniaHeadlessFilePickingTests
 {
-    private static bool _setupDone;
-    
     public AvaloniaHeadlessFilePickingTests()
     {
-        if (!_setupDone)
-        {
-            AppBuilder.Configure<App>()
-                .UseHeadless(new AvaloniaHeadlessPlatformOptions())
-                .SetupWithoutStarting();
-            
-            TranslationManager.Init();
-            if (TranslationManager.Translation != null)
-            {
-                TranslationManager.Translation.Folder = "Folder";
-                TranslationManager.Translation.SaveAs = "SaveAs";
-                TranslationManager.Translation.OpenFileDialog = "Open";
-            }
-
-            _setupDone = true;
-        }
-    }
-
-    private T RunWithDispatcher<T>(Task<T> task)
-    {
-        while (!task.IsCompleted)
-        {
-            Dispatcher.UIThread.RunJobs();
-            Thread.Sleep(10);
-        }
-        return task.GetAwaiter().GetResult();
+        TranslationManager.Init();
+        TranslationManager.Translation.Folder = "Folder";
+        TranslationManager.Translation.SaveAs = "SaveAs";
+        TranslationManager.Translation.OpenFileDialog = "Open";
     }
 
     [Fact]
-    public void SelectFile_HeadlessNoopProvider_ShouldReturnNull()
+    public async Task SelectFile_HeadlessNoopProvider_ShouldReturnNull()
     {
-        var window = new Window();
-        var sp = window.StorageProvider;
-        
-        var service = new FilePickerService(sp);
-        var result = RunWithDispatcher(service.SelectFile());
+        var service = new FilePickerService(null);
+        var result = await service.SelectFile();
         
         Assert.Null(result);
     }
 
     [Fact]
-    public void SelectDirectory_HeadlessNoopProvider_ShouldReturnEmptyString()
+    public async Task SelectDirectory_HeadlessNoopProvider_ShouldReturnEmptyString()
     {
-        var window = new Window();
-        var sp = window.StorageProvider;
-        
-        var service = new FilePickerService(sp);
-        var result = RunWithDispatcher(service.SelectDirectory());
+        var service = new FilePickerService(null);
+        var result = await service.SelectDirectory();
         
         Assert.Equal(string.Empty, result);
     }
 
     [Fact]
-    public void PickFileForSavingAsync_HeadlessNoopProvider_ShouldReturnNull()
+    public async Task PickFileForSavingAsync_HeadlessNoopProvider_ShouldReturnNull()
     {
-        var window = new Window();
-        var sp = window.StorageProvider;
-        
-        var service = new FilePickerService(sp);
-        var result = RunWithDispatcher(service.PickFileForSavingAsync("test.jpg"));
+        var service = new FilePickerService(null);
+        var result = await service.PickFileForSavingAsync("test.jpg");
         
         Assert.Null(result);
     }

--- a/src/PicView.Tests/FileTests/AvaloniaHeadlessSavingTests.cs
+++ b/src/PicView.Tests/FileTests/AvaloniaHeadlessSavingTests.cs
@@ -1,94 +1,57 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Headless;
-using Avalonia.Threading;
-using PicView.Avalonia;
 using PicView.Avalonia.FileSystem;
 using PicView.Core.Localization;
 using PicView.Core.ViewModels;
 
 namespace PicView.Tests.FileTests;
 
+[Collection("Sequential")]
 public class AvaloniaHeadlessSavingTests
 {
-    private static bool _setupDone;
-    
     public AvaloniaHeadlessSavingTests()
     {
-        if (!_setupDone)
-        {
-            AppBuilder.Configure<App>()
-                .UseHeadless(new AvaloniaHeadlessPlatformOptions())
-                .SetupWithoutStarting();
-            
-            LoadSettings();
+        LoadSettings();
 
-            TranslationManager.Init();
-            if (TranslationManager.Translation != null)
-            {
-                TranslationManager.Translation.Folder = "Folder";
-                TranslationManager.Translation.SaveAs = "SaveAs";
-                TranslationManager.Translation.OpenFileDialog = "Open";
-            }
-
-            _setupDone = true;
-        }
+        TranslationManager.Init();
+        TranslationManager.Translation.Folder = "Folder";
+        TranslationManager.Translation.SaveAs = "SaveAs";
+        TranslationManager.Translation.OpenFileDialog = "Open";
     }
 
-    private T RunWithDispatcher<T>(ValueTask<T> task)
-    {
-        while (!task.IsCompleted)
-        {
-            Dispatcher.UIThread.RunJobs();
-            Thread.Sleep(10);
-        }
-        return task.GetAwaiter().GetResult();
-    }
-
-    private MainWindowViewModel CreateDummyVm()
+    private static MainWindowViewModel CreateDummyVm()
     {
         // Try creating with null dependencies since they might just be saved to properties
         return new MainWindowViewModel(null!, null!, null!, null!);
     }
 
     [Fact]
-    public void SaveCurrentFile_HeadlessNoopProvider_ReturnsFalseWhenContextIsNull()
+    public async Task SaveCurrentFile_HeadlessNoopProvider_ReturnsFalseWhenContextIsNull()
     {
         var vm = CreateDummyVm();
-        var window = new Window();
-        var sp = window.StorageProvider;
-        var pickerService = new FilePickerService(sp);
+        var pickerService = new FilePickerService(null);
         var savingService = new FileSavingService(pickerService);
-        
-        var result = RunWithDispatcher(savingService.SaveCurrentFile(vm));
+        var result = await savingService.SaveCurrentFile(vm);
         
         Assert.False(result);
     }
     
     [Fact]
-    public void SaveFileAs_HeadlessNoopProvider_ReturnsFalse()
+    public async Task SaveFileAs_HeadlessNoopProvider_ReturnsFalse()
     {
         var vm = CreateDummyVm();
-        var window = new Window();
-        var sp = window.StorageProvider;
-        var pickerService = new FilePickerService(sp);
+        var pickerService = new FilePickerService(null);
         var savingService = new FileSavingService(pickerService);
-        
-        var result = RunWithDispatcher(savingService.SaveFileAs(vm));
+        var result = await savingService.SaveFileAs(vm);
         
         Assert.False(result);
     }
 
     [Fact]
-    public void SaveFileAsync_HeadlessNoopProvider_ReturnsFalseWhenDataContextIsNull()
+    public async Task SaveFileAsync_HeadlessNoopProvider_ReturnsFalseWhenDataContextIsNull()
     {
         var vm = CreateDummyVm();
-        var window = new Window();
-        var sp = window.StorageProvider;
-        var pickerService = new FilePickerService(sp);
+        var pickerService = new FilePickerService(null);
         var savingService = new FileSavingService(pickerService);
-        
-        var result = RunWithDispatcher(savingService.SaveFileAsync("test.jpg", "test.jpg", vm));
+        var result = await savingService.SaveFileAsync("test.jpg", "test.jpg", vm);
         
         Assert.False(result);
     }

--- a/src/PicView.Tests/FileTests/TempFileManagerTests.cs
+++ b/src/PicView.Tests/FileTests/TempFileManagerTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 
 namespace PicView.Tests.FileTests;
 
+[Collection("Sequential")]
 public class TempFileManagerTests : IDisposable
 {
     public TempFileManagerTests()

--- a/src/PicView.Tests/Gallery/GalleryNavigationTests.cs
+++ b/src/PicView.Tests/Gallery/GalleryNavigationTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace PicView.Tests.Gallery;
 
+[Collection("Sequential")]
 public class GalleryNavigationTests
 {
     public GalleryNavigationTests()

--- a/src/PicView.Tests/Gallery/GalleryViewModelTests.cs
+++ b/src/PicView.Tests/Gallery/GalleryViewModelTests.cs
@@ -6,6 +6,7 @@ using R3;
 
 namespace PicView.Tests.Gallery;
 
+[Collection("Sequential")]
 public class GalleryViewModelTests
 {
     private readonly ManualFrameProvider _frameProvider;

--- a/src/PicView.Tests/LanguageAndSettingsUnitTest.cs
+++ b/src/PicView.Tests/LanguageAndSettingsUnitTest.cs
@@ -1,9 +1,10 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using PicView.Core.Localization;
 using ZLinq;
 
 namespace PicView.Tests;
 
+[Collection("Sequential")]
 public class LanguageAndSettingsUnitTest
 {
     [Fact]

--- a/src/PicView.Tests/Navigation/FileWatcherServiceTests.cs
+++ b/src/PicView.Tests/Navigation/FileWatcherServiceTests.cs
@@ -9,6 +9,7 @@ using R3;
 
 namespace PicView.Tests.Navigation;
 
+[Collection("Sequential")]
 public class FileWatcherServiceTests : IDisposable
 {
     private readonly FileWatcherService _service;

--- a/src/PicView.Tests/Navigation/NavigationServiceTests.cs
+++ b/src/PicView.Tests/Navigation/NavigationServiceTests.cs
@@ -115,10 +115,11 @@ public class NavigationServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task LoadFromArchiveAsync_ExtractsInitialSeedFiles_AndResetsLoadingIndicator()
+    public async Task LoadFromArchiveAsync_AlwaysUncompressEntireArchiveTrue_ExtractsInitial10SeedFiles()
     {
-        var tempZipPath = Path.Combine(_testDirectory, "test_archive.zip");
-        var archiveSourceDir = Path.Combine(_testDirectory, "archive_source");
+        Settings.Navigation.AlwaysUncompressEntireArchive = true;
+        var tempZipPath = Path.Combine(_testDirectory, "test_archive_true.zip");
+        var archiveSourceDir = Path.Combine(_testDirectory, "archive_source_true");
         Directory.CreateDirectory(archiveSourceDir);
 
         for (var i = 1; i <= 15; i++)
@@ -131,18 +132,65 @@ public class NavigationServiceTests : IDisposable
         var tab = CreateTab(_testDirectory);
         var cts = new CancellationTokenSource();
 
-        var success = await _navigationService.LoadFromArchiveAsync(tempZipPath, tab, cts);
+        try
+        {
+            var success = await _navigationService.LoadFromArchiveAsync(tempZipPath, tab, cts);
 
-        Assert.True(success);
-        Assert.True(tab.ArchiveExtractionService.IsArchived);
-        Assert.NotNull(tab.ImageIterator.Files);
-        // Initially populated with 10 seed files
-        Assert.True(tab.ImageIterator.Files.Count >= 10);
-        Assert.NotNull(tab.Model);
-        Assert.NotNull(tab.Model.FileInfo);
-        Assert.True(File.Exists(tab.Model.FileInfo.FullName));
+            Assert.True(success);
+            Assert.True(tab.ArchiveExtractionService.IsArchived);
+            Assert.NotNull(tab.ImageIterator.Files);
+            // Initially populated with 10 seed files
+            Assert.True(tab.ImageIterator.Files.Count >= 10);
+            Assert.NotNull(tab.Model);
+            Assert.NotNull(tab.Model.FileInfo);
+            Assert.True(File.Exists(tab.Model.FileInfo.FullName));
+        }
+        finally
+        {
+            tab.ArchiveExtractionService.Cleanup();
+            Settings.Navigation.AlwaysUncompressEntireArchive = false;
+        }
+    }
 
-        tab.ArchiveExtractionService.Cleanup();
+    [Fact]
+    public async Task LoadFromArchiveAsync_AlwaysUncompressEntireArchiveFalse_ExtractsSingleSeedFile()
+    {
+        Settings.Navigation.AlwaysUncompressEntireArchive = false;
+        var tempZipPath = Path.Combine(_testDirectory, "test_archive_false.zip");
+        var archiveSourceDir = Path.Combine(_testDirectory, "archive_source_false");
+        Directory.CreateDirectory(archiveSourceDir);
+
+        for (var i = 1; i <= 15; i++)
+        {
+            await File.WriteAllBytesAsync(Path.Combine(archiveSourceDir, $"img_{i:D2}.jpg"), [0xFF, 0xD8, 0xFF]);
+        }
+
+        System.IO.Compression.ZipFile.CreateFromDirectory(archiveSourceDir, tempZipPath);
+
+        var tab = CreateTab(_testDirectory);
+        var cts = new CancellationTokenSource();
+
+        try
+        {
+            var success = await _navigationService.LoadFromArchiveAsync(tempZipPath, tab, cts);
+
+            Assert.True(success);
+            Assert.True(tab.ArchiveExtractionService.IsArchived);
+            Assert.NotNull(tab.ImageIterator.Files);
+            // Initially seeded with 1 file (or 2 if side-by-side)
+            Assert.True(tab.ImageIterator.Files.Count >= 1);
+            Assert.NotNull(tab.Model);
+            Assert.NotNull(tab.Model.FileInfo);
+            Assert.True(File.Exists(tab.Model.FileInfo.FullName));
+            // Enables forward navigation while extracting in background
+            Assert.True(tab.CanNavigateForwards.Value);
+            // Should not show the batched progress text indicator
+            Assert.Null(tab.ArchiveExtractionProgressText.Value);
+        }
+        finally
+        {
+            tab.ArchiveExtractionService.Cleanup();
+        }
     }
 
     [Fact]

--- a/src/PicView.Tests/Navigation/NavigationServiceTests.cs
+++ b/src/PicView.Tests/Navigation/NavigationServiceTests.cs
@@ -104,14 +104,45 @@ public class NavigationServiceTests : IDisposable
         Assert.True(_mockThumbnailLoader.GetThumbnailAsyncCalledCount > 0, "Gallery should be reloaded (GetThumbnailAsync called)");
     }
 
-    private TabViewModel CreateTab(string directory)
+    private TabViewModel CreateTab(string directory, MainWindowViewModel? parentVm = null)
     {
-        var tab = new TabViewModel(null!, null!);
+        var tab = new TabViewModel(null!, parentVm!);
         // Initialize with mocks to avoid null refs
         var thumbCache = new MockThumbnailCache();
         tab.Initialize(_mockCache, thumbCache, _mockThumbnailLoader, null, thumbCache);
         tab.ImageIterator.Files = new List<FileInfo>();
         return tab;
+    }
+
+    [Fact]
+    public async Task LoadFromArchiveAsync_ExtractsInitialSeedFiles_AndResetsLoadingIndicator()
+    {
+        var tempZipPath = Path.Combine(_testDirectory, "test_archive.zip");
+        var archiveSourceDir = Path.Combine(_testDirectory, "archive_source");
+        Directory.CreateDirectory(archiveSourceDir);
+
+        for (var i = 1; i <= 15; i++)
+        {
+            await File.WriteAllBytesAsync(Path.Combine(archiveSourceDir, $"img_{i:D2}.jpg"), [0xFF, 0xD8, 0xFF]);
+        }
+
+        System.IO.Compression.ZipFile.CreateFromDirectory(archiveSourceDir, tempZipPath);
+
+        var tab = CreateTab(_testDirectory);
+        var cts = new CancellationTokenSource();
+
+        var success = await _navigationService.LoadFromArchiveAsync(tempZipPath, tab, cts);
+
+        Assert.True(success);
+        Assert.True(tab.ArchiveExtractionService.IsArchived);
+        Assert.NotNull(tab.ImageIterator.Files);
+        // Initially populated with 10 seed files
+        Assert.True(tab.ImageIterator.Files.Count >= 10);
+        Assert.NotNull(tab.Model);
+        Assert.NotNull(tab.Model.FileInfo);
+        Assert.True(File.Exists(tab.Model.FileInfo.FullName));
+
+        tab.ArchiveExtractionService.Cleanup();
     }
 
     [Fact]

--- a/src/PicView.Tests/PrintPreviewViewModelTests.cs
+++ b/src/PicView.Tests/PrintPreviewViewModelTests.cs
@@ -2,6 +2,7 @@ using PicView.Core.ViewModels;
 
 namespace PicView.Tests;
 
+[Collection("Sequential")]
 public class PrintPreviewViewModelTests
 {
     public PrintPreviewViewModelTests()

--- a/src/PicView.Tests/Resizing/BatchResizeViewModelTests.cs
+++ b/src/PicView.Tests/Resizing/BatchResizeViewModelTests.cs
@@ -6,10 +6,13 @@ using R3;
 
 namespace PicView.Tests.Resizing;
 
+[Collection("Sequential")]
 public class BatchResizeViewModelTests
 {
     public BatchResizeViewModelTests()
     {
+        SetDefaults();
+        TranslationManager.Init();
         ObservableSystem.DefaultFrameProvider = new MockFrameProvider();
     }
 

--- a/src/PicView.Tests/SettingsViewModelTests.cs
+++ b/src/PicView.Tests/SettingsViewModelTests.cs
@@ -6,6 +6,7 @@ using R3;
 
 namespace PicView.Tests;
 
+[Collection("Sequential")]
 public class SettingsViewModelTests
 {
     public SettingsViewModelTests()

--- a/src/PicView.Tests/Update/AboutViewModelTests.cs
+++ b/src/PicView.Tests/Update/AboutViewModelTests.cs
@@ -1,10 +1,11 @@
-﻿using PicView.Core.IPlatform;
+using PicView.Core.IPlatform;
 using PicView.Core.Localization;
 using PicView.Core.Update;
 using PicView.Core.ViewModels;
 
 namespace PicView.Tests.Update;
 
+[Collection("Sequential")]
 public class AboutViewModelTests
 {
     public AboutViewModelTests()

--- a/src/PicView.Tests/Update/UpdateManagerTests.cs
+++ b/src/PicView.Tests/Update/UpdateManagerTests.cs
@@ -3,6 +3,7 @@ using PicView.Core.IPlatform;
 
 namespace PicView.Tests.Update;
 
+[Collection("Sequential")]
 public class UpdateManagerTests
 {
     private class DummyPlatformUpdate : IPlatformSpecificUpdate


### PR DESCRIPTION
## Description
I was pretty happy with the new 'Navigation > Always uncompress entire archive folder' feature I added in [my last PR](https://github.com/Ruben2776/PicView/pull/368), but I wanted to improve it further.  In the last version, when you had the new option checked it would extract the whole archive, but the UI would block with a spinner while it was extracting.  In the new version, it now uncompresses the first 10 images, then unblocks the UI so you can start viewing them while the remaining images are uncompressed in batches of 10 with a small status indicator in the bottom right corner.

Obviously up to @Ruben2776 but I think this feature is ready to be enabled by default, as it makes image archive / comic viewing a much better experience.

## Motivation and Context
The primary motivation was that waiting for the entire archive to uncompress made the user wait unnecessarily.  With the new batch decompression, the user can begin viewing the images in the archive almost immediately, while the rest of the archive decompresses in the background.

## How Has This Been Tested?
All tests were updated to work with the new logic.  New tests were added to cover.  I also ensured that the default path (with the Always uncompress entire archive folder option disabled) was unaffected and worked the same as before.

## Screenshots (if appropriate):
<img width="183" height="84" alt="image" src="https://github.com/user-attachments/assets/83b2f0e2-b5b8-461f-b1c1-7a95f29bf8da" />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
