### PR TITLE
Fix macOS bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -368,3 +368,9 @@ MigrationBackup/
 
 # Cross-compiled picview-ffmpeg native libraries (produced by Build\Build-FFmpegNative.ps1)
 Build/ffmpeg-native/
+
+# Packaged macOS app bundle output (produced by Build\Build Avalonia.MacOS.ps1)
+Build/mac-release/
+
+# macOS Finder metadata
+.DS_Store

--- a/src/PicView.Avalonia.MacOS/App.axaml.cs
+++ b/src/PicView.Avalonia.MacOS/App.axaml.cs
@@ -92,6 +92,10 @@ public class App : Application, IPlatformSpecificService
         SettingsUpdater.InitializeSettings(_mainWindowViewModel, settingsExists);
         WindowFunctions.HandleWindowScalingMode(_coreViewModel, _mainWindow);
         _mainWindow.Show();
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
+        {
+            desktopLifetime.MainWindow = _mainWindow;
+        }
 
         var arg = Environment.GetCommandLineArgs();
         if (arg.Length > 1)

--- a/src/PicView.Avalonia.MacOS/App.axaml.cs
+++ b/src/PicView.Avalonia.MacOS/App.axaml.cs
@@ -78,20 +78,21 @@ public class App : Application, IPlatformSpecificService
         TranslationManager.Init();
 
         _coreViewModel = new CoreViewModel(this, GetImageModel.GetImageModelAsync);
-        DataContext = _coreViewModel;
 
         ThemeManager.DetermineTheme(Current, settingsExists);
 
-        _mainWindow = new MacMainWindow();
+        _mainWindow = new MacMainWindow(_coreViewModel);
         _mainWindowViewModel = _mainWindow.DataContext as MainWindowViewModel;
         _coreViewModel.MainWindows.MainWindows.Add(_mainWindowViewModel);
         _coreViewModel.MainWindows.ActiveWindow.Value = _mainWindowViewModel;
+
+        DataContext = _coreViewModel;
         
         TranslationManager.Init();
         SettingsUpdater.InitializeSettings(_mainWindowViewModel, settingsExists);
         WindowFunctions.HandleWindowScalingMode(_coreViewModel, _mainWindow);
         _mainWindow.Show();
-        
+
         var arg = Environment.GetCommandLineArgs();
         if (arg.Length > 1)
         {

--- a/src/PicView.Avalonia.MacOS/Views/MacMainWindow.axaml.cs
+++ b/src/PicView.Avalonia.MacOS/Views/MacMainWindow.axaml.cs
@@ -16,9 +16,14 @@ namespace PicView.Avalonia.MacOS.Views;
 
 public partial class MacMainWindow : MainWindow, IPlatformWindowService
 {
-    public MacMainWindow()
+    public MacMainWindow() : this(null)
     {
-        if (Application.Current.DataContext is not CoreViewModel core)
+    }
+
+    public MacMainWindow(CoreViewModel? core)
+    {
+        core ??= Application.Current?.DataContext as CoreViewModel;
+        if (core is null)
         {
             return;
         }

--- a/src/PicView.Avalonia.Win32/Views/FileAssociationWindow.axaml
+++ b/src/PicView.Avalonia.Win32/Views/FileAssociationWindow.axaml
@@ -149,7 +149,7 @@
                                 Text="{CompiledBinding AssociationsViewModel.FilterText.Value,
                                                        FallbackValue='',
                                                        Mode=TwoWay}"
-                                Watermark="{CompiledBinding Translation.Filter.Value,
+                                PlaceholderText="{CompiledBinding Translation.Filter.Value,
                                                             Mode=OneWay}" />
 
                             <customControls:IconButton

--- a/src/PicView.Avalonia/CustomControls/DateTimeInput.axaml.cs
+++ b/src/PicView.Avalonia/CustomControls/DateTimeInput.axaml.cs
@@ -231,7 +231,7 @@ public class DateTimeInput : TemplatedControl
         var textBox = new ValidationTextBox
         {
             MaxLength = maxLength,
-            Watermark = watermark,
+            PlaceholderText = watermark,
             TextAlignment = TextAlignment.Center,
             VerticalAlignment = VerticalAlignment.Center,
             Padding = new Thickness(0),

--- a/src/PicView.Avalonia/CustomControls/PicBox.cs
+++ b/src/PicView.Avalonia/CustomControls/PicBox.cs
@@ -53,8 +53,8 @@ public class PicBox : Control
     /// <summary>
     ///     Defines the <see cref="ImageType" /> property.
     /// </summary>
-    public static readonly AvaloniaProperty<ImageType> ImageTypeProperty =
-        AvaloniaProperty.Register<PicBox, ImageType>(nameof(ImageType));
+    public static readonly StyledProperty<ImageType?> ImageTypeProperty =
+        AvaloniaProperty.Register<PicBox, ImageType?>(nameof(ImageType));
     
     public static readonly StyledProperty<FileInfo?> CurrentFileInfoProperty =
         AvaloniaProperty.Register<PicBox, FileInfo?>(nameof(CurrentFileInfo));
@@ -69,7 +69,7 @@ public class PicBox : Control
     /// </summary>
     public ImageType ImageType
     {
-        get => (ImageType)(GetValue(ImageTypeProperty) ?? false);
+        get => GetValue(ImageTypeProperty) ?? ImageType.Invalid;
         set => SetValue(ImageTypeProperty, value);
     }
 

--- a/src/PicView.Avalonia/ImageHandling/GetImageModel.cs
+++ b/src/PicView.Avalonia/ImageHandling/GetImageModel.cs
@@ -17,7 +17,7 @@ public static class GetImageModel
 {
     /// <inheritdoc cref="GetImageModelAsync(System.IO.FileInfo, MagickImage)"/>
     public static async ValueTask<ImageModel> GetImageModelAsync(FileInfo fileInfo) =>
-        await GetImageModelAsync(fileInfo, null).ConfigureAwait(false);
+        await GetImageModelAsync(fileInfo, null).ConfigureAwait(false) ?? CreateErrorImageModel(fileInfo);
 
     /// <summary>
     /// Asynchronously retrieves an <see cref="ImageModel"/> instance based on the provided file and optional <see cref="MagickImage"/>.

--- a/src/PicView.Avalonia/Input/MouseShortcuts.cs
+++ b/src/PicView.Avalonia/Input/MouseShortcuts.cs
@@ -211,7 +211,10 @@ public static class MouseShortcuts
                 case NavigationMode.None:
                     return;
                 case NavigationMode.NavigatingFileHistory:
-                    await windowViewModel.Mapper.OpenPreviousFileHistoryEntry().ConfigureAwait(false);
+                    if (windowViewModel.Mapper is not null)
+                    {
+                        await windowViewModel.Mapper.OpenPreviousFileHistoryEntry().ConfigureAwait(false);
+                    }
                     return;
                 case NavigationMode.NavigatingBetweenDirectories:
                     await windowViewModel.WindowTabs.PrevFolder().ConfigureAwait(false);
@@ -232,7 +235,10 @@ public static class MouseShortcuts
                 case NavigationMode.None:
                     return;
                 case NavigationMode.NavigatingFileHistory:
-                    await windowViewModel.Mapper.OpenNextFileHistoryEntry().ConfigureAwait(false);
+                    if (windowViewModel.Mapper is not null)
+                    {
+                        await windowViewModel.Mapper.OpenNextFileHistoryEntry().ConfigureAwait(false);
+                    }
                     return;
                 case NavigationMode.NavigatingBetweenDirectories:
                     await windowViewModel.WindowTabs.NextFolder().ConfigureAwait(false);
@@ -248,7 +254,7 @@ public static class MouseShortcuts
         // Handle double click (only for the left mouse button, so that rapid
         // double-clicks of the side buttons don't fall through and trigger the
         // left-button double-click behavior such as toggling fullscreen)
-        if (e.ClickCount is 2 && prop.IsLeftButtonPressed)
+        if (e.ClickCount is 2 && prop.IsLeftButtonPressed && windowViewModel.Mapper is not null)
         {
             switch (Settings.UIProperties.DoubleClickBehavior)
             {

--- a/src/PicView.Avalonia/PicViewTheme/Controls/NumericUpDown.axaml
+++ b/src/PicView.Avalonia/PicViewTheme/Controls/NumericUpDown.axaml
@@ -41,7 +41,7 @@
                             TextAlignment="{TemplateBinding TextAlignment}"
                             TextWrapping="NoWrap"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Watermark="{TemplateBinding Watermark}" />
+                            PlaceholderText="{TemplateBinding Watermark}" />
                     </ButtonSpinner>
                 </DataValidationErrors>
             </ControlTemplate>

--- a/src/PicView.Avalonia/PicViewTheme/Controls/TextBox.axaml
+++ b/src/PicView.Avalonia/PicViewTheme/Controls/TextBox.axaml
@@ -43,7 +43,7 @@
                                                                         Converter={x:Static StringConverters.IsNullOrEmpty}}"
                                             Name="watermark"
                                             Opacity="0.5"
-                                            Text="{TemplateBinding Watermark}"
+                                            Text="{TemplateBinding PlaceholderText}"
                                             TextAlignment="{TemplateBinding TextAlignment}"
                                             TextWrapping="{TemplateBinding TextWrapping}"
                                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />

--- a/src/PicView.Avalonia/UI/HoverFadeButtonHandler.cs
+++ b/src/PicView.Avalonia/UI/HoverFadeButtonHandler.cs
@@ -108,7 +108,7 @@ public class HoverFadeButtonHandler : IDisposable
     /// </summary>
     private bool IsPointerOver()
     {
-        if ((bool)_mainButton?.IsPointerOver)
+        if (_mainButton?.IsPointerOver == true)
         {
             return true;
         }

--- a/src/PicView.Avalonia/Views/Main/BatchResizeView.axaml
+++ b/src/PicView.Avalonia/Views/Main/BatchResizeView.axaml
@@ -276,7 +276,7 @@
                             Text="{CompiledBinding BatchResize.FilterText.Value,
                                                    FallbackValue='',
                                                    Mode=TwoWay}"
-                            Watermark="{CompiledBinding Translation.Filter.Value,
+                            PlaceholderText="{CompiledBinding Translation.Filter.Value,
                                                         Mode=OneWay}" />
 
                         <!--  File count  -->

--- a/src/PicView.Avalonia/Views/Main/EffectsView.axaml.cs
+++ b/src/PicView.Avalonia/Views/Main/EffectsView.axaml.cs
@@ -244,7 +244,7 @@ public partial class EffectsView : UserControl
             {
                 if (_reloading)
                 {
-                    return (Config: null, Vm: effectsViewModel);
+                    return (Config: (ImageEffectConfig?)null, Vm: effectsViewModel);
                 }
         
                 var config = effectsViewModel.EffectConfig.Value ??= new ImageEffectConfig();

--- a/src/PicView.Avalonia/Views/Main/KeybindingsView.axaml
+++ b/src/PicView.Avalonia/Views/Main/KeybindingsView.axaml
@@ -30,7 +30,7 @@
                 Text="{CompiledBinding Keybindings.FilterText.Value,
                                        FallbackValue='',
                                        Mode=TwoWay}"
-                Watermark="{CompiledBinding Translation.Filter.Value,
+                PlaceholderText="{CompiledBinding Translation.Filter.Value,
                                             Mode=OneWay}" />
 
             <!--  clear  -->

--- a/src/PicView.Avalonia/Views/Main/SettingsView.axaml
+++ b/src/PicView.Avalonia/Views/Main/SettingsView.axaml
@@ -90,7 +90,7 @@
                 Foreground="{DynamicResource MainTextColor}"
                 Text="{CompiledBinding SettingsViewModel.SearchQuery.Value,
                                        Mode=TwoWay}"
-                Watermark="{CompiledBinding Translation.Search.Value,
+                PlaceholderText="{CompiledBinding Translation.Search.Value,
                                             Mode=OneWay}" />
 
             <Popup

--- a/src/PicView.Avalonia/Views/UC/PopUps/FileSearchDialog.axaml
+++ b/src/PicView.Avalonia/Views/UC/PopUps/FileSearchDialog.axaml
@@ -78,7 +78,7 @@
                     Focusable="True"
                     FontFamily="/Assets/Fonts/Roboto-Regular.ttf#Roboto"
                     Foreground="{DynamicResource MainTextColor}"
-                    Watermark="{CompiledBinding Translation.Search.Value,
+                    PlaceholderText="{CompiledBinding Translation.Search.Value,
                                                 Mode=OneWay}" />
             </Panel>
 

--- a/src/PicView.Core/FileHistory/FileHistoryManager.cs
+++ b/src/PicView.Core/FileHistory/FileHistoryManager.cs
@@ -355,7 +355,13 @@ public static class FileHistoryManager
         
         try
         {
-            var bytes = File.ReadAllBytes(_fileHistoryConfiguration.TryGetCurrentUserConfigPath);
+            var configPath = _fileHistoryConfiguration.TryGetCurrentUserConfigPath;
+            if (string.IsNullOrEmpty(configPath))
+            {
+                return;
+            }
+
+            var bytes = File.ReadAllBytes(configPath);
 
             if (JsonSerializer.Deserialize(bytes, typeof(FileHistoryEntries),
                     FileHistoryGenerationContext.Default)

--- a/src/PicView.Core/Localization/TranslationManager.cs
+++ b/src/PicView.Core/Localization/TranslationManager.cs
@@ -116,7 +116,10 @@ public static class TranslationManager
     {
         var jsonString = await File.ReadAllTextAsync(filePath).ConfigureAwait(false);
         var language = JsonSerializer.Deserialize(jsonString, typeof(LanguageModel), LanguageSourceGenerationContext.Default) as LanguageModel;
-        Translation = language;
+        if (language is not null)
+        {
+            Translation = language;
+        }
     }
 
     /// <summary>

--- a/src/PicView.Core/ViewModels/FileHistoryEntryViewModel.cs
+++ b/src/PicView.Core/ViewModels/FileHistoryEntryViewModel.cs
@@ -5,7 +5,7 @@ namespace PicView.Core.ViewModels;
 
 public class FileHistoryEntryViewModel : IDisposable 
 {
-    private MainWindowViewModel _vm;
+    private MainWindowViewModel _vm = null!;
     public BindableReactiveProperty<string> FilePath { get; } = new();
     public BindableReactiveProperty<string> FileName { get; } = new();
     public BindableReactiveProperty<bool> IsPinned { get; } = new();

--- a/src/PicView.Core/ViewModels/GalleryViewModel.cs
+++ b/src/PicView.Core/ViewModels/GalleryViewModel.cs
@@ -38,7 +38,13 @@ public class GalleryViewModel : IDisposable
     public void Initialize()
     {
         GallerySettingsConverter.UpdateDockPositionProperties(this);
-        Observable.EveryValueChanged(Settings.Gallery, g => g.IsGalleryDocked)
+
+        if (Settings.Gallery is not { } gallery)
+        {
+            return;
+        }
+
+        Observable.EveryValueChanged(gallery, g => g.IsGalleryDocked)
         .Subscribe(isDocked =>
         {
             if (isDocked && ActiveGalleryMode.Value is GalleryMode.Closed)
@@ -60,14 +66,14 @@ public class GalleryViewModel : IDisposable
         }, DebugHelper.LogError(nameof(GalleryViewModel), nameof(Initialize)))
         .AddTo(ref _disposables);
 
-        Observable.EveryValueChanged(Settings.Gallery, g => g.ItemSpacing)
+        Observable.EveryValueChanged(gallery, g => g.ItemSpacing)
         .Subscribe(x =>
         {
             ItemSpacing.Value = x;
         }, DebugHelper.LogError(nameof(GalleryViewModel), nameof(Initialize)))
         .AddTo(ref _disposables);
 
-        Observable.EveryValueChanged(Settings.Gallery, g => g.LineSpacing)
+        Observable.EveryValueChanged(gallery, g => g.LineSpacing)
         .Subscribe(x =>
         {
             LineSpacing.Value = x;
@@ -138,7 +144,7 @@ public class GalleryViewModel : IDisposable
         }, DebugHelper.LogError(nameof(GalleryViewModel), nameof(Initialize)))
         .AddTo(ref _disposables);
         
-        Observable.EveryValueChanged(Settings.Gallery, x => x.IsGalleryDocked)
+        Observable.EveryValueChanged(gallery, x => x.IsGalleryDocked)
         .Skip(1)
         .Subscribe(x =>
         {
@@ -157,7 +163,7 @@ public class GalleryViewModel : IDisposable
         }, DebugHelper.LogError(nameof(GalleryViewModel), nameof(Initialize)))
         .AddTo(ref _disposables);
         
-        Observable.EveryValueChanged(Settings.Gallery, x => x.DockPosition)
+        Observable.EveryValueChanged(gallery, x => x.DockPosition)
         .Skip(1)
         .Subscribe(_ => { GallerySettingsConverter.UpdateDockPositionProperties(this); }, DebugHelper.LogError(nameof(GalleryViewModel), nameof(Initialize)))
         .AddTo(ref _disposables);

--- a/src/PicView.Core/ViewModels/KeybindingsViewModel.cs
+++ b/src/PicView.Core/ViewModels/KeybindingsViewModel.cs
@@ -7,7 +7,7 @@ namespace PicView.Core.ViewModels;
 
 public class KeybindingsViewModel : IDisposable
 {
-    public KeybindingWindowConfig WindowConfig { get; set; }
+    public KeybindingWindowConfig WindowConfig { get; set; } = new();
     
     private readonly CompositeDisposable _disposables = new();
     


### PR DESCRIPTION
## Description
Fixes several macOS startup and runtime bugs. Some only reproducible in the packaged `.app` bundle, not when running via `dotnet run` and clears a batch of compiler/analyzer build warnings.

**Bug fixes:**
- **macOS file open dialog dead until app refocused** — `FilePickerService` resolves its `IStorageProvider` from `desktop.MainWindow`, but macOS only set `MainWindow` in `MainWindow.OnActivated`, so it was `null` until the app was first focused. Now assigned during startup right after `Show()`, matching the existing Linux startup path. (`App.axaml.cs`)
- **Crash on early mouse click** — `MainWindowViewModel.Mapper` is initialized in a background task, so a double-click / side-button click during startup threw a `NullReferenceException`. Added null guards. (`MouseShortcuts.cs`)
- **Crash loading file history** — `FileHistoryManager.LoadFromFile` passed an empty path to `File.ReadAllBytes` on first run (no history file yet). It now returns early when the path is empty. (`FileHistoryManager.cs`)
- **Native menu binding warnings** — the app `DataContext` was assigned before `MainWindows.ActiveWindow.Value`, so the macOS `NativeMenu` bound against a `null` value. `MacMainWindow` now takes the `CoreViewModel` via constructor so `DataContext` is set after `ActiveWindow.Value`. (`App.axaml.cs`, `MacMainWindow.axaml.cs`)
- **PicBox `ImageType` binding errors** — the property was registered as the non-nullable `ImageType` enum, but the bound source is `ImageType?` and `null` before an image loads. Registered as `StyledProperty<ImageType?>` and coalesced to `ImageType.Invalid`. (`PicBox.cs`)

**Build warning cleanup:**
- Nullable-reference warnings (CS8634/CS8622/CS8618/CS8601/CS8603/CS8629/CS8619) across `GalleryViewModel`, `FileHistoryEntryViewModel`, `KeybindingsViewModel`, `TranslationManager`, `GetImageModel`, `HoverFadeButtonHandler`, and `EffectsView`.
- Migrated obsolete `TextBox.Watermark` to `PlaceholderText` (AVLN5001/CS0618), including the custom `TextBox`/`NumericUpDown` control-theme templates that render the watermark, so watermarks keep working.

**Chore:**
- `.gitignore`: ignore the packaged `Build/mac-release/` output and `.DS_Store`.

## Motivation and Context
The packaged macOS `.app` had several rough edges — most notably the **Select a File** / **Open** buttons doing nothing until the user switched to another app and back — plus a couple of startup crashes and a large set of pre-existing build warnings. These changes make the macOS build cleaner and more robust, and reduce build noise.

## How Has This Been Tested?
- Built and ran the macOS app on Apple Silicon, both via `dotnet run` (Debug) and as a Release, self-contained, Native AOT `.app` bundle launched from Finder / `open`.
- Verified the **Select a File** / **Open** buttons work immediately on launch from the bundle without needing to refocus.
- Verified no `NullReferenceException` on early clicks, no first-run file-history crash, and that the native-menu / `PicBox` binding errors no longer appear in the log.
- Confirmed the macOS app builds with the targeted warnings resolved.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.